### PR TITLE
Member 도메인 리팩토링

### DIFF
--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/SigninRequestDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/SigninRequestDto.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 @Getter
 @Builder
@@ -12,4 +13,8 @@ import lombok.NoArgsConstructor;
 public class SigninRequestDto {
     private String email;
     private String password;
+
+    public UsernamePasswordAuthenticationToken toAuthenticationToken() {
+        return new UsernamePasswordAuthenticationToken(email, password);
+    }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/SignupRequestDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/SignupRequestDto.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import our.yurivongella.instagramclone.domain.member.Member;
 
 @Getter
 @Builder
@@ -14,4 +16,13 @@ public class SignupRequestDto {
     private String email;
     private String nickName;
     private String password;
+
+    public Member toMember(PasswordEncoder passwordEncoder) {
+        return Member.builder()
+                .name(name)
+                .email(email)
+                .password(passwordEncoder.encode(password))
+                .nickName(nickName)
+                .build();
+    }
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/follow/Follow.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/follow/Follow.java
@@ -16,10 +16,13 @@ import lombok.NoArgsConstructor;
 import our.yurivongella.instagramclone.domain.BaseEntity;
 import our.yurivongella.instagramclone.domain.member.Member;
 
-@Table(name = "follow")
 @Getter
 @Entity
 @NoArgsConstructor
+@Table(
+        name = "follow",
+        uniqueConstraints = {@UniqueConstraint(columnNames = { "from_member_id", "to_member_id" })}
+)
 public class Follow extends BaseEntity {
 
     @Id

--- a/src/main/java/our/yurivongella/instagramclone/domain/follow/Follow.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/follow/Follow.java
@@ -1,14 +1,6 @@
 package our.yurivongella.instagramclone.domain.follow;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.FetchType;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
-import javax.persistence.Table;
+import javax.persistence.*;
 
 import lombok.Builder;
 import lombok.Getter;
@@ -38,24 +30,17 @@ public class Follow extends BaseEntity {
     @JoinColumn(name = "to_member_id")
     private Member toMember;
 
-    @Deprecated
     @Builder
     public Follow(Member fromMember, Member toMember) {
         this.fromMember = fromMember;
         this.toMember = toMember;
+        fromMember.getFollowings().add(this);
+        toMember.getFollowers().add(this);
     }
 
-    public void addFollow(Member fromMember, Member toMember) {
-        this.fromMember = fromMember;
-        this.toMember = toMember;
-
-        fromMember.getFollowers().add(this);
-        toMember.getFollowings().add(this);
-    }
-
-    public void unFollow() {
+    public Follow unfollow() {
         this.fromMember.getFollowings().remove(this);
         this.toMember.getFollowers().remove(this);
+        return this;
     }
-
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/follow/FollowRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/follow/FollowRepository.java
@@ -11,4 +11,6 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
     List<Follow> findByToMemberId(Long id);
 
     Optional<Follow> findByFromMemberIdAndToMemberId(Long fromMemberId, Long toMemberId);
+
+    boolean existsByFromMemberIdAndToMemberId(Long fromMemberId, Long toMemberId);
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/member/Member.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/member/Member.java
@@ -2,6 +2,7 @@ package our.yurivongella.instagramclone.domain.member;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import javax.persistence.*;
 
@@ -62,20 +63,7 @@ public class Member extends BaseEntity {
         this.authority = Authority.ROLE_USER;
     }
 
-    public Follow follow(Member targetMember) {
-        Follow follow = Follow.builder()
-                              .fromMember(this)
-                              .toMember(targetMember)
-                              .build();
-
-        this.followings.add(follow);
-        targetMember.followers.add(follow);
-        return follow;
+    public boolean equals(Member other) {
+        return Objects.equals(id, other.getId()) || Objects.equals(email, other.getEmail());
     }
-
-    public void unFollow(Follow follow) {
-        follow.getToMember().getFollowers().remove(follow);
-        this.followings.remove(follow);
-    }
-
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/member/MemberRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/member/MemberRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    boolean existsByEmail(String email);
 }

--- a/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
@@ -35,8 +35,7 @@ public class AuthService {
 
     public TokenDto signin(SigninRequestDto signinRequestDto) {
         // 1. username, password 를 기반으로 AuthenticationToken 생성
-        UsernamePasswordAuthenticationToken authenticationToken =
-                new UsernamePasswordAuthenticationToken(signinRequestDto.getEmail(), signinRequestDto.getPassword());
+        UsernamePasswordAuthenticationToken authenticationToken = signinRequestDto.toAuthenticationToken();
 
         // 2. 실제로 검증 (사용자 비밀번호 체크) 이 이루어지는 부분
         // authenticate 메서드가 실행이 될 때 CustomUserDetailsService 에서 만들었던 loadUserByUsername 메서드가 실행됨

--- a/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
@@ -15,8 +15,6 @@ import our.yurivongella.instagramclone.domain.member.Member;
 import our.yurivongella.instagramclone.domain.member.MemberRepository;
 import our.yurivongella.instagramclone.jwt.TokenProvider;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class AuthService {
@@ -27,19 +25,11 @@ public class AuthService {
 
     @Transactional
     public String signup(SignupRequestDto signupRequestDto) {
-        Optional<Member> existsMember = memberRepository.findByEmail(signupRequestDto.getEmail());
-
-        if (existsMember.isPresent()) {
+        if (memberRepository.existsByEmail(signupRequestDto.getEmail())) {
             throw new RuntimeException("이미 가입되어 있는 유저입니다");
         }
 
-        Member member = Member.builder()
-                .name(signupRequestDto.getName())
-                .email(signupRequestDto.getEmail())
-                .password(passwordEncoder.encode(signupRequestDto.getPassword()))
-                .nickName(signupRequestDto.getNickName())
-                .build();
-
+        Member member = signupRequestDto.toMember(passwordEncoder);
         return memberRepository.save(member).getEmail();
     }
 

--- a/src/test/java/our/yurivongella/instagramclone/service/MemberServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/MemberServiceTest.java
@@ -208,9 +208,9 @@ class MemberServiceTest {
             Member member2 = memberRepository.findByEmail(targetEmail).get();
             Member member3 = memberRepository.findByEmail(targetEmail + 3).get();
 
-            member1.follow(member2);
-            member1.follow(member3);
-            member2.follow(member1);
+            followRepository.save(Follow.builder().fromMember(member1).toMember(member2).build());
+            followRepository.save(Follow.builder().fromMember(member1).toMember(member3).build());
+            followRepository.save(Follow.builder().fromMember(member2).toMember(member1).build());
 
             // 한명 로그인 처리
             Authentication authentication =


### PR DESCRIPTION
## Description

#28 ISSUE 에 이은 추가 수정입니다.

전반적으로 기능에 대한 변화는 없고 리팩토링만 진행했습니다.

팔로우에 대한 고민이 많았습니다.

1. 행위의 주체가 Member 니까 Member 엔티티에 있어야 할까?
2. 실질적으로 DB 에서 처리되는건 Follow 뿐이니까 Follow Entity 에 있어야 할까??

처음에는 1 번처럼 생각해서 짰었는데 `member.follow(other)` 는 자연스러운데 비해 `member.unfollow(follow)` 는 굉장히 부자연스러웠습니다.

그리고 FollowRepository 를 직접 조회하지 않고 Member Entity 에 있는 팔로우 리스트를 사용하려고 하니,

만약 팔로우 리스트가 엄청 많다면 언팔로우 한번을 위해 모든 팔로우를 가져와서 찾는건 비효율적이지 않나? 라는 생각도 들어서

Follow Entity 에서 만드는걸로 변경했습니다.

## Changes

- Optional 이쁘게 사용
-  코드 다이어트
- 팔로우/언팔로우를 Member 엔티티에서 Follow 엔티티에서 하도록 변경
