### PR TITLE
feat: Refresh 추가 및 Security 코드 리팩토링

### DIFF
--- a/src/main/java/our/yurivongella/instagramclone/config/JwtSecurityConfig.java
+++ b/src/main/java/our/yurivongella/instagramclone/config/JwtSecurityConfig.java
@@ -1,5 +1,6 @@
 package our.yurivongella.instagramclone.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
@@ -7,12 +8,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import our.yurivongella.instagramclone.jwt.JwtFilter;
 import our.yurivongella.instagramclone.jwt.TokenProvider;
 
+@RequiredArgsConstructor
 public class JwtSecurityConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
-    private TokenProvider tokenProvider;
-
-    public JwtSecurityConfig(TokenProvider tokenProvider) {
-        this.tokenProvider = tokenProvider;
-    }
+    private final TokenProvider tokenProvider;
 
     // TokenProvider 를 주입받아서 JwtFilter 를 통해 Security 로직에 필터를 등록
     @Override

--- a/src/main/java/our/yurivongella/instagramclone/config/SecurityConfig.java
+++ b/src/main/java/our/yurivongella/instagramclone/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package our.yurivongella.instagramclone.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -16,28 +17,18 @@ import our.yurivongella.instagramclone.jwt.TokenProvider;
 
 @Configuration
 @EnableWebSecurity
-@EnableGlobalMethodSecurity(prePostEnabled = true)  // @PreSuthorize 어노테이션을 메소드 단위로 추가하기 위해 적용
+@RequiredArgsConstructor
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final TokenProvider tokenProvider;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
-
-    public SecurityConfig(
-            TokenProvider tokenProvider,
-            JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint,
-            JwtAccessDeniedHandler jwtAccessDeniedHandler
-    ) {
-        this.tokenProvider = tokenProvider;
-        this.jwtAuthenticationEntryPoint = jwtAuthenticationEntryPoint;
-        this.jwtAccessDeniedHandler = jwtAccessDeniedHandler;
-    }
 
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
 
-    // h2 database 테스트가 원활하도록 관련 API 들은 전부 무시
+    // h2-console 과 swagger 관련 API 들은 전부 패스
     @Override
     public void configure(WebSecurity web) {
         web.ignoring()
@@ -73,11 +64,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .sessionManagement()
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 
-                // 로그인, 회원가입 API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
+                // auth API 는 토큰이 없는 상태에서 요청이 들어오기 때문에 permitAll 설정
                 .and()
                 .authorizeRequests()
-                .antMatchers("/auth/signin").permitAll()
-                .antMatchers("/auth/signup").permitAll()
+                .antMatchers("/auth/**").permitAll()
                 .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요
 
                 // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용

--- a/src/main/java/our/yurivongella/instagramclone/controller/AuthController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/AuthController.java
@@ -1,5 +1,6 @@
 package our.yurivongella.instagramclone.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -9,18 +10,14 @@ import org.springframework.web.bind.annotation.RestController;
 import our.yurivongella.instagramclone.controller.dto.SigninRequestDto;
 import our.yurivongella.instagramclone.controller.dto.TokenDto;
 import our.yurivongella.instagramclone.controller.dto.SignupRequestDto;
+import our.yurivongella.instagramclone.controller.dto.TokenRequestDto;
 import our.yurivongella.instagramclone.service.AuthService;
-
-import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequestMapping("/auth")
+@RequiredArgsConstructor
 public class AuthController {
     private final AuthService authService;
-
-    public AuthController(AuthService authService) {
-        this.authService = authService;
-    }
 
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody SignupRequestDto signupRequestDto) {
@@ -32,5 +29,10 @@ public class AuthController {
     public ResponseEntity<TokenDto> signin(@RequestBody SigninRequestDto signinRequestDto) {
         TokenDto tokenDto = authService.signin(signinRequestDto);
         return ResponseEntity.ok(tokenDto);
+    }
+
+    @PostMapping("/reissue")
+    public ResponseEntity<TokenDto> reissue(@RequestBody TokenRequestDto tokenRequestDto) {
+        return ResponseEntity.ok(authService.reissue(tokenRequestDto));
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/TokenRequestDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/TokenRequestDto.java
@@ -1,10 +1,14 @@
 package our.yurivongella.instagramclone.controller.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class TokenRequestDto {
     private String accessToken;
     private String refreshToken;

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/TokenRequestDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/TokenRequestDto.java
@@ -1,14 +1,11 @@
 package our.yurivongella.instagramclone.controller.dto;
 
-import lombok.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Builder
 @NoArgsConstructor
-@AllArgsConstructor
-public class TokenDto {
-    private String grantType;
+public class TokenRequestDto {
     private String accessToken;
     private String refreshToken;
-    private Long accessTokenExpiresIn;
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/refeshtoken/RefreshToken.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/refeshtoken/RefreshToken.java
@@ -1,0 +1,31 @@
+package our.yurivongella.instagramclone.domain.refeshtoken;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Getter
+@NoArgsConstructor
+@Table(name = "refresh_token")
+@Entity
+public class RefreshToken {
+
+    @Id
+    private String key;
+    private String value;
+
+    @Builder
+    public RefreshToken(String key, String value) {
+        this.key = key;
+        this.value = value;
+    }
+
+    public RefreshToken updateValue(String token) {
+        this.value = token;
+        return this;
+    }
+}

--- a/src/main/java/our/yurivongella/instagramclone/domain/refeshtoken/RefreshTokenRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/refeshtoken/RefreshTokenRepository.java
@@ -1,0 +1,11 @@
+package our.yurivongella.instagramclone.domain.refeshtoken;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByKey(String key);
+}

--- a/src/main/java/our/yurivongella/instagramclone/jwt/JwtFilter.java
+++ b/src/main/java/our/yurivongella/instagramclone/jwt/JwtFilter.java
@@ -1,35 +1,32 @@
 package our.yurivongella.instagramclone.jwt;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
-import org.springframework.web.filter.GenericFilterBean;
+import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
-import javax.servlet.ServletRequest;
-import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 
-public class JwtFilter extends GenericFilterBean {
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter {
 
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String BEARER_PREFIX = "Bearer ";
 
     private final TokenProvider tokenProvider;
 
-    public JwtFilter(TokenProvider tokenProvider) {
-        this.tokenProvider = tokenProvider;
-    }
-
-    // 실제 필터링 로직은 doFilter 에 들어감
-    // JWT 토큰의 인증 정보를 현재 실행중인 SecurityContext 에 저장하는 역할 수행
+    // 실제 필터링 로직은 doFilterInternal 에 들어감
+    // JWT 토큰의 인증 정보를 현재 쓰레드의 SecurityContext 에 저장하는 역할 수행
     @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        // 1. Request 에서 토큰을 꺼냄
-        HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-        String jwt = resolveToken(httpServletRequest);
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        // 1. Request Header 에서 토큰을 꺼냄
+        String jwt = resolveToken(request);
 
         // 2. validateToken 으로 토큰 유효성 검사
         // 정상 토큰이면 해당 토큰으로 Authentication 을 가져와서 SecurityContext 에 저장
@@ -38,7 +35,7 @@ public class JwtFilter extends GenericFilterBean {
             SecurityContextHolder.getContext().setAuthentication(authentication);
         }
 
-        filterChain.doFilter(servletRequest, servletResponse);
+        filterChain.doFilter(request, response);
     }
 
     // Request Header 에서 토큰 정보를 꺼내오기 위한 resolveToken 메소드 추가

--- a/src/main/java/our/yurivongella/instagramclone/jwt/TokenProvider.java
+++ b/src/main/java/our/yurivongella/instagramclone/jwt/TokenProvider.java
@@ -10,7 +10,9 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+import our.yurivongella.instagramclone.controller.dto.TokenDto;
 
 import java.security.Key;
 import java.util.Arrays;
@@ -22,7 +24,9 @@ import java.util.stream.Collectors;
 @Component
 public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
-    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;  // 토큰 유효시간 30분
+    private static final String BEARER_TYPE = "bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
 
     private final Key key;
 
@@ -31,33 +35,44 @@ public class TokenProvider {
         this.key = Keys.hmacShaKeyFor(keyBytes);
     }
 
-    public String createAccessToken(Authentication authentication) {
+    public TokenDto generateTokenDto(Authentication authentication) {
         // 권한들 가져오기
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
-        // 만료시간 설정
         long now = (new Date()).getTime();
-        Date validity = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
 
-        // JWT 토큰 생성해서 리턴
-        return Jwts.builder()
+        // Access Token 생성
+        Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
+        String accessToken = Jwts.builder()
                 .setSubject(authentication.getName())       // payload "sub": "name"
-                .claim(AUTHORITIES_KEY, authorities)        // payload "AUTHORITIES_KEY": "authorities"
-                .setExpiration(validity)                    // payload "exp": 1516239022 (임시)
+                .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
+                .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
                 .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
                 .compact();
+
+        // Refresh Token 생성
+        String refreshToken = Jwts.builder()
+                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                .signWith(key, SignatureAlgorithm.HS512)
+                .compact();
+
+        return TokenDto.builder()
+                .grantType(BEARER_TYPE)
+                .accessToken(accessToken)
+                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                .refreshToken(refreshToken)
+                .build();
     }
 
-    public Authentication getAuthentication(String token) {
-        // 토큰으로 클레임 만들기
-        Claims claims = Jwts
-                .parserBuilder()
-                .setSigningKey(key)
-                .build()
-                .parseClaimsJws(token)
-                .getBody();
+    public Authentication getAuthentication(String accessToken) {
+        // 토큰 복호화
+        Claims claims = parseClaims(accessToken);
+
+        if (claims.get(AUTHORITIES_KEY) == null) {
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
 
         // 클레임에서 권한 정보 가져오기
         Collection<? extends GrantedAuthority> authorities =
@@ -66,9 +81,9 @@ public class TokenProvider {
                         .collect(Collectors.toList());
 
         // UserDetails 객체를 만들어서 Authentication 리턴
-        User principal = new User(claims.getSubject(), "", authorities);
+        UserDetails principal = new User(claims.getSubject(), "", authorities);
 
-        return new UsernamePasswordAuthenticationToken(principal, token, authorities);
+        return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
     public boolean validateToken(String token) {
@@ -85,5 +100,13 @@ public class TokenProvider {
             log.info("JWT 토큰이 잘못되었습니다.");
         }
         return false;
+    }
+
+    private Claims parseClaims(String accessToken) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
@@ -11,8 +11,11 @@ import org.springframework.transaction.annotation.Transactional;
 import our.yurivongella.instagramclone.controller.dto.SigninRequestDto;
 import our.yurivongella.instagramclone.controller.dto.SignupRequestDto;
 import our.yurivongella.instagramclone.controller.dto.TokenDto;
+import our.yurivongella.instagramclone.controller.dto.TokenRequestDto;
 import our.yurivongella.instagramclone.domain.member.Member;
 import our.yurivongella.instagramclone.domain.member.MemberRepository;
+import our.yurivongella.instagramclone.domain.refeshtoken.RefreshToken;
+import our.yurivongella.instagramclone.domain.refeshtoken.RefreshTokenRepository;
 import our.yurivongella.instagramclone.jwt.TokenProvider;
 
 @Service
@@ -20,8 +23,9 @@ import our.yurivongella.instagramclone.jwt.TokenProvider;
 public class AuthService {
     private final TokenProvider tokenProvider;
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
-    private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MemberRepository memberRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @Transactional
     public String signup(SignupRequestDto signupRequestDto) {
@@ -33,20 +37,57 @@ public class AuthService {
         return memberRepository.save(member).getEmail();
     }
 
+    @Transactional
     public TokenDto signin(SigninRequestDto signinRequestDto) {
         // 1. username, password 를 기반으로 AuthenticationToken 생성
         UsernamePasswordAuthenticationToken authenticationToken = signinRequestDto.toAuthenticationToken();
 
         // 2. 실제로 검증 (사용자 비밀번호 체크) 이 이루어지는 부분
-        // authenticate 메서드가 실행이 될 때 CustomUserDetailsService 에서 만들었던 loadUserByUsername 메서드가 실행됨
+        //    authenticate 메서드가 실행이 될 때 CustomUserDetailsService 에서 만들었던 loadUserByUsername 메서드가 실행됨
         Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
 
-        // 3. SecurityContext 에 인증 정보 저장
-        SecurityContextHolder.getContext().setAuthentication(authentication);
+        // 3. 인증 정보를 기반으로 JWT 토큰 생성
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
 
-        // 4. 인증 정보를 기반으로 JWT Access 토큰 생성
-        String accessToken = tokenProvider.createAccessToken(authentication);
+        // 4. RefreshToken 저장
+        RefreshToken refreshToken = RefreshToken.builder()
+                .key(authentication.getName())
+                .value(tokenDto.getRefreshToken())
+                .build();
 
-        return TokenDto.builder().accessToken(accessToken).build();
+        refreshTokenRepository.save(refreshToken);
+
+        // 5. 토큰 발급
+        return tokenDto;
+    }
+
+    @Transactional
+    public TokenDto reissue(TokenRequestDto tokenRequestDto) {
+        // 1. Refresh Token 검증
+        if (!tokenProvider.validateToken(tokenRequestDto.getRefreshToken())) {
+            throw new RuntimeException("Refresh Token 이 유효하지 않습니다.");
+        }
+
+        // 2. Access Token 에서 Member ID 가져오기
+        Authentication authentication = tokenProvider.getAuthentication(tokenRequestDto.getAccessToken());
+
+        // 3. 저장소에서 Member ID 를 기반으로 Refresh Token 값 가져옴
+        RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName())
+                .orElseThrow(() -> new RuntimeException("로그아웃 된 사용자입니다."));
+
+        // 4. Refresh Token 일치하는지 검사
+        if (!refreshToken.getValue().equals(tokenRequestDto.getRefreshToken())) {
+            throw new RuntimeException("토큰의 유저 정보가 일치하지 않습니다.");
+        }
+
+        // 5. 새로운 토큰 생성
+        TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
+
+        // 6. 저장소 정보 업데이트
+        RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
+        refreshTokenRepository.save(newRefreshToken);
+
+        // 토큰 발급
+        return tokenDto;
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
@@ -84,8 +84,7 @@ public class AuthService {
         TokenDto tokenDto = tokenProvider.generateTokenDto(authentication);
 
         // 6. 저장소 정보 업데이트
-        RefreshToken newRefreshToken = refreshToken.updateValue(tokenDto.getRefreshToken());
-        refreshTokenRepository.save(newRefreshToken);
+        refreshToken.updateValue(tokenDto.getRefreshToken());
 
         // 토큰 발급
         return tokenDto;

--- a/src/main/java/our/yurivongella/instagramclone/service/CustomUserDetailsService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/CustomUserDetailsService.java
@@ -1,5 +1,6 @@
 package our.yurivongella.instagramclone.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -14,13 +15,10 @@ import our.yurivongella.instagramclone.domain.member.MemberRepository;
 import java.util.Collections;
 
 @Service
+@RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
 
     private final MemberRepository memberRepository;
-
-    public CustomUserDetailsService(MemberRepository memberRepository) {
-        this.memberRepository = memberRepository;
-    }
 
     @Override
     @Transactional

--- a/src/main/java/our/yurivongella/instagramclone/util/SecurityUtil.java
+++ b/src/main/java/our/yurivongella/instagramclone/util/SecurityUtil.java
@@ -5,13 +5,10 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 public class SecurityUtil {
 
-    private SecurityUtil() {
-
-    }
+    private SecurityUtil() { }
 
     // SecurityContext 에 유저 정보가 저장되는 시점
-    // 1. 로그인 할 때는 AuthController 에서 인증 완료 후 저장
-    // 2. Request 가 들어올 때 JwtFilter 의 doFilter 메서드에서 저장
+    // Request 가 들어올 때 JwtFilter 의 doFilter 메서드에서 저장
     public static Long getCurrentMemberId() {
         final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 

--- a/src/test/java/our/yurivongella/instagramclone/service/AuthServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/AuthServiceTest.java
@@ -104,15 +104,9 @@ public class AuthServiceTest {
 
             // then
             assertThat(tokenDto.getAccessToken()).isNotNull();
-
-            Optional<Member> member = memberRepository.findById(SecurityUtil.getCurrentMemberId());
-            assertThat(member.isPresent()).isTrue();
-            assertThat(member.get().getNickName()).isEqualTo(nickName);
-            assertThat(member.get().getName()).isEqualTo(name);
-            assertThat(member.get().getEmail()).isEqualTo(email);
-            assertThat(
-                    passwordEncoder.matches(password, member.get().getPassword())
-            ).isTrue();
+            assertThat(tokenDto.getRefreshToken()).isNotNull();
+            assertThat(tokenDto.getGrantType()).isNotNull();
+            assertThat(tokenDto.getAccessTokenExpiresIn()).isNotNull();
         }
 
         @DisplayName("이메일 불일치로 실패")


### PR DESCRIPTION
## Description

#27 ISSUE 에 관한 내용

Refresh Token 발급하도록 추가했습니다.

[Wiki](https://github.com/INSPJT/instagram_clone_backend/wiki/Spring-Security---JWT) 에도 내용 추가했으니 궁금하신 분은 한번 읽어봐도 좋을 것 같네요

그리고 Spring Bean 생성자 주입하는 애들 `@RequiredArgsConstructor` 어노테이션으로 수정했습니다.

## Changes

- 로그인 시 Access Token + Refresh Token 같이 내려줌
- Access Token 만료되면 Exception
- 재발급 요청할 때 Access Token + Refresh Token 을 HttpRequest Body 에 담아서 같이 보내줘야함
- 재발급 시 Access Token + Refresh Token 같이 내려줌
- 리프레시 토큰 저장소 추가 (임시로 해놨고 나중에 Redis 로 교체 필요)
