### PR TITLE
refactor: RESTful 형식에 맞춰서 API URI 형식 수정

### DIFF
--- a/src/main/java/our/yurivongella/instagramclone/controller/AuthController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/AuthController.java
@@ -1,5 +1,6 @@
 package our.yurivongella.instagramclone.controller;
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,18 +20,21 @@ import our.yurivongella.instagramclone.service.AuthService;
 public class AuthController {
     private final AuthService authService;
 
+    @ApiOperation("가입하기")
     @PostMapping("/signup")
     public ResponseEntity<String> signup(@RequestBody SignupRequestDto signupRequestDto) {
         String email = authService.signup(signupRequestDto);
         return ResponseEntity.status(HttpStatus.CREATED).body(email + " 회원가입이 완료되었습니다.");
     }
 
+    @ApiOperation("로그인")
     @PostMapping("/signin")
     public ResponseEntity<TokenDto> signin(@RequestBody SigninRequestDto signinRequestDto) {
         TokenDto tokenDto = authService.signin(signinRequestDto);
         return ResponseEntity.ok(tokenDto);
     }
 
+    @ApiOperation("로그인 토큰 재발급")
     @PostMapping("/reissue")
     public ResponseEntity<TokenDto> reissue(@RequestBody TokenRequestDto tokenRequestDto) {
         return ResponseEntity.ok(authService.reissue(tokenRequestDto));

--- a/src/main/java/our/yurivongella/instagramclone/controller/CommentController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/CommentController.java
@@ -23,39 +23,38 @@ import our.yurivongella.instagramclone.service.CommentService;
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-@RequestMapping("/comment")
 public class CommentController {
     private final CommentService commentService;
 
-    @ApiOperation("postId를 넘겨주면 해당 포스트의 댓글들을 조회합니다.")
-    @GetMapping("/{postId}")
+    @ApiOperation("게시글의 댓글 리스트 조회")
+    @GetMapping("/posts/{postId}/comments")
     public ResponseEntity<?> getComments(@PathVariable("postId") Long postId) {
         List<CommentResponseDto> comments = commentService.getComments(postId);
         return ResponseEntity.ok(comments);
     }
 
-    @ApiOperation("postId에 해당하는 포스트에 content를 넘겨주면 댓글이 생성됩니다.")
-    @PostMapping("/{postId}")
+    @ApiOperation("게시글에 content 로 새로운 댓글 생성")
+    @PostMapping("/posts/{postId}/comments")
     public ResponseEntity<?> createComment(@PathVariable("postId") Long postId, @RequestBody CommentCreateDto commentCreateDto) {
         return ResponseEntity.ok(commentService.createComment(postId, commentCreateDto));
     }
 
-    @ApiOperation("commentId에 해당하는 댓글을 삭제합니다.")
-    @DeleteMapping("/{commentId}")
+    @ApiOperation("해당 댓글 삭제")
+    @DeleteMapping("/comments/{commentId}")
     public ResponseEntity<?> deleteComment(@PathVariable("commentId") Long commentId) throws Exception {
         ProcessStatus processStatus = commentService.deleteComment(commentId);
         return ResponseEntity.ok(processStatus.getMessage());
     }
 
-    @ApiOperation("commentId에 해당하는 댓글을 좋아요 표시합니다.")
-    @PutMapping("/like/{commentId}")
+    @ApiOperation("댓글에 좋아요")
+    @PutMapping("/comments/{commentId}/like")
     public ResponseEntity<?> likeComment(@PathVariable("commentId") Long commentId) throws Exception {
         ProcessStatus processStatus = commentService.likeComment(commentId);
         return ResponseEntity.ok(processStatus.getMessage());
     }
 
-    @ApiOperation("commentId에 해당하는 댓글 좋아요를 취소합니다.")
-    @DeleteMapping("/like/{commentId}")
+    @ApiOperation("댓글 좋아요 취소")
+    @DeleteMapping("/comments/{commentId}/like")
     public ResponseEntity<?> unlikeComment(@PathVariable("commentId") Long commentId) throws Exception {
         ProcessStatus processStatus = commentService.unlikeComment(commentId);
         return ResponseEntity.ok(processStatus.getMessage());

--- a/src/main/java/our/yurivongella/instagramclone/controller/MemberController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/MemberController.java
@@ -2,6 +2,7 @@ package our.yurivongella.instagramclone.controller;
 
 import java.util.List;
 
+import io.swagger.annotations.ApiOperation;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,23 +17,27 @@ import our.yurivongella.instagramclone.service.MemberService;
 public class MemberController {
     private final MemberService memberService;
 
-    @PutMapping("/follow")
-    public ResponseEntity<String> follow(@RequestBody FollowRequestDto followRequestDto) {
-        boolean success = memberService.follow(followRequestDto);
+    @ApiOperation("상대방 팔로우")
+    @PutMapping("/follow/{memberId}")
+    public ResponseEntity<String> follow(@PathVariable Long memberId) {
+        boolean success = memberService.follow(memberId);
         return ResponseEntity.ok("팔로우 결과: " + success);
     }
 
-    @PutMapping("/unfollow")
-    public ResponseEntity<String> unfollow(@RequestBody FollowRequestDto followRequestDto) {
-        boolean success = memberService.unFollow(followRequestDto);
+    @ApiOperation("상대방 언팔로우")
+    @DeleteMapping("/follow/{memberId}")
+    public ResponseEntity<String> unfollow(@PathVariable Long memberId) {
+        boolean success = memberService.unFollow(memberId);
         return ResponseEntity.ok("언팔로우 결과: " + success);
     }
 
+    @ApiOperation("나를 팔로우 하는 Followers 조회")
     @GetMapping("/followers")
     public ResponseEntity<List<MemberResponseDto>> getFollowers() {
         return ResponseEntity.ok(memberService.getFollowers());
     }
 
+    @ApiOperation("내가 팔로우 하는 Followings 조회")
     @GetMapping("/followings")
     public ResponseEntity<List<MemberResponseDto>> getFollowing() {
         return ResponseEntity.ok(memberService.getFollowings());

--- a/src/main/java/our/yurivongella/instagramclone/controller/PostController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/PostController.java
@@ -1,5 +1,6 @@
 package our.yurivongella.instagramclone.controller;
 
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -16,28 +17,31 @@ import java.util.Optional;
 
 @RequiredArgsConstructor
 @RestController
-@RequestMapping("/post")
 public class PostController {
 
     private final PostService postService;
 
-    @PostMapping
+    @ApiOperation("새로운 게시글 생성")
+    @PostMapping("/posts")
     public ResponseEntity<String> create(@RequestBody PostCreateRequestDto postRequestDto) {
         Long id = postService.create(postRequestDto); // mock users
         return ResponseEntity.ok(id + "인 포스트가 만들어졌습니다.");
     }
 
-    @GetMapping("/{postId}")
+    @ApiOperation("특정 게시글 하나 가져오기")
+    @GetMapping("/posts/{postId}")
     public ResponseEntity<PostReadResponseDto> read(@PathVariable Long postId) {
         return ResponseEntity.ok(postService.read(postId));
     }
 
-    @DeleteMapping("/{postId}")
+    @ApiOperation("특정 게시글 하나 삭제")
+    @DeleteMapping("/posts/{postId}")
     public ResponseEntity<?> delete(@PathVariable Long postId) {
         ProcessStatus processStatus = postService.delete(postId);
         return ResponseEntity.ok(processStatus.getMessage());
     }
 
+    @ApiOperation("특정 사용자의 게시글 리스트 조회")
     @GetMapping("/members/{memberId}/posts")
     public ResponseEntity<?> readPostList(@PathVariable Long memberId) {
         return ResponseEntity.ok(postService.getPostList(memberId));

--- a/src/main/java/our/yurivongella/instagramclone/domain/member/Member.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/member/Member.java
@@ -63,10 +63,10 @@ public class Member extends BaseEntity {
     @OneToMany(mappedBy = "member")
     private List<CommentLike> commentLikes = new ArrayList<>();
 
-    @OneToMany(mappedBy = "toMember")
+    @OneToMany(mappedBy = "fromMember")
     private List<Follow> followings = new ArrayList<>();
 
-    @OneToMany(mappedBy = "fromMember")
+    @OneToMany(mappedBy = "toMember")
     private List<Follow> followers = new ArrayList<>();
 
     @Builder

--- a/src/main/java/our/yurivongella/instagramclone/service/MemberService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/MemberService.java
@@ -9,7 +9,6 @@ import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
-import our.yurivongella.instagramclone.controller.dto.FollowRequestDto;
 import our.yurivongella.instagramclone.controller.dto.MemberResponseDto;
 import our.yurivongella.instagramclone.domain.follow.Follow;
 import our.yurivongella.instagramclone.domain.follow.FollowRepository;
@@ -24,14 +23,14 @@ public class MemberService {
     private final FollowRepository followRepository;
 
     @Transactional
-    public boolean follow(FollowRequestDto followRequestDto) {
-        Member currentMember = getCurrentMember();
-        Member targetMember = memberRepository.findById(followRequestDto.getId())
-                .orElseThrow(() -> new RuntimeException("팔로우 대상이 존재하지 않습니다."));
-
-        if (currentMember.equals(targetMember))  {
+    public boolean follow(Long memberId) {
+        if (SecurityUtil.getCurrentMemberId().equals(memberId))  {
             throw new RuntimeException("자기 자신은 팔로우 할 수 없습니다.");
         }
+
+        Member currentMember = getCurrentMember();
+        Member targetMember = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("팔로우 대상이 존재하지 않습니다."));
 
         try {
             Follow follow = Follow.builder()
@@ -47,10 +46,10 @@ public class MemberService {
     }
 
     @Transactional
-    public boolean unFollow(FollowRequestDto followRequestDto) {
+    public boolean unFollow(Long memberId) {
         Follow follow = followRepository.findByFromMemberIdAndToMemberId(
                                 SecurityUtil.getCurrentMemberId(),
-                                followRequestDto.getId()
+                                memberId
                         )
                         .orElseThrow(() -> new RuntimeException("팔로우 중이지 않습니다."))
                         .unfollow();

--- a/src/test/java/our/yurivongella/instagramclone/service/MemberServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/MemberServiceTest.java
@@ -96,13 +96,8 @@ class MemberServiceTest {
         @DisplayName("팔로우 성공")
         @Test
         public void successFollow() {
-            // given
-            FollowRequestDto followRequestDto = FollowRequestDto.builder()
-                    .id(targetId)
-                    .build();
-
             // when
-            memberService.follow(followRequestDto);
+            memberService.follow(targetId);
 
             // then
             List<Follow> follows = followRepository.findByToMemberId(targetId);
@@ -125,18 +120,13 @@ class MemberServiceTest {
         @DisplayName("이미 팔로우 중임")
         @Test
         public void alreadyFollow() {
-            // given
-            FollowRequestDto followRequestDto = FollowRequestDto.builder()
-                    .id(targetId)
-                    .build();
-
             // when
-            memberService.follow(followRequestDto);
+            memberService.follow(targetId);
 
             // then
             Assertions.assertThrows(
                     RuntimeException.class,
-                    () -> memberService.follow(followRequestDto)
+                    () -> memberService.follow(targetId)
             );
         }
     }
@@ -157,23 +147,14 @@ class MemberServiceTest {
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
             // 언팔로우 테스트를 위해 미리 팔로우 처리
-            FollowRequestDto followRequestDto = FollowRequestDto.builder()
-                    .id(targetId)
-                    .build();
-
-            memberService.follow(followRequestDto);
+            memberService.follow(targetId);
         }
 
         @DisplayName("언팔로우 성공")
         @Test
         public void successUnFollow() {
-            // given
-            FollowRequestDto followRequestDto = FollowRequestDto.builder()
-                    .id(targetId)
-                    .build();
-
             // when
-            memberService.unFollow(followRequestDto);
+            memberService.unFollow(targetId);
 
             // then
             List<Follow> follows = followRepository.findByToMemberId(targetId);
@@ -183,18 +164,13 @@ class MemberServiceTest {
         @DisplayName("팔로우 중이지 않아서 실패")
         @Test
         public void notFollowingTarget() {
-            // given
-            FollowRequestDto followRequestDto = FollowRequestDto.builder()
-                    .id(targetId)
-                    .build();
-
             // when
-            memberService.unFollow(followRequestDto);
+            memberService.unFollow(targetId);
 
             // then
             Assertions.assertThrows(
                     RuntimeException.class,
-                    () -> memberService.unFollow(followRequestDto)
+                    () -> memberService.unFollow(targetId)
             );
         }
     }

--- a/src/test/java/our/yurivongella/instagramclone/service/MemberServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/MemberServiceTest.java
@@ -9,6 +9,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.transaction.annotation.Transactional;
 import our.yurivongella.instagramclone.controller.dto.FollowRequestDto;
+import our.yurivongella.instagramclone.controller.dto.MemberResponseDto;
 import our.yurivongella.instagramclone.controller.dto.SignupRequestDto;
 import our.yurivongella.instagramclone.domain.follow.Follow;
 import our.yurivongella.instagramclone.domain.follow.FollowRepository;
@@ -221,13 +222,18 @@ class MemberServiceTest {
         @DisplayName("내 팔로워 가져오기")
         @Test
         public void getFollowersTest() {
-            assertThat(memberService.getFollowers().size()).isEqualTo(1);
+            List<MemberResponseDto> followers = memberService.getFollowers();
+            assertThat(followers.get(0).getDisplayId()).isEqualTo(targetDisplayId);
+            assertThat(followers.size()).isEqualTo(1);
         }
 
         @DisplayName("내 팔로우 중인 대상들 가져오기")
         @Test
         public void getFollowingTest() {
-            assertThat(memberService.getFollowings().size()).isEqualTo(2);
+            List<MemberResponseDto> followings = memberService.getFollowings();
+            assertThat(followings.get(0).getDisplayId()).isEqualTo(targetDisplayId);
+            assertThat(followings.get(1).getDisplayId()).isEqualTo(targetDisplayId + 3);
+            assertThat(followings.size()).isEqualTo(2);
         }
     }
 }


### PR DESCRIPTION
## Description

ISSUE #41 

RESTful 형식에 맞춰서 URI 형식 변경

**기본적인 규칙**

- 자원 (Resource) 에 대한 표현은 항상 복수
- "나" 에 대한 액션은 단수 표현 (`/member`)
- 포함 관계를 나타내는 경우는 연달아서 표현: 특정 게시글의 댓글 리스트 조회 `/posts/{postId}/comments/{commentId}`

**Github API 에 좋은 예시들이 있어서 많이 참고했습니다.**

- [Follow](https://docs.github.com/en/rest/reference/users#followers)
- 좋아요는 [Star](https://docs.github.com/en/rest/reference/gists#star-a-gist) 참고
- [Comment](https://docs.github.com/en/rest/reference/gists#comments)

<br>

## Changes

- URI 형식 변경
- Followings, Followers 관계 반대로 되어 있던거 수정
- Swagger ApiOperation 추가
