### PR TITLE
Post Like 기능 추가, Count 필드 추가 및 조회 성능 개선, displayId 적용

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: 
 labels: bug
-assignees: AndoneKwon, bjh7013, DolphaGo, goodGid, heonilp, ParkJiwoon, syureu
+assignees: AndoneKwon, DolphaGo, goodGid, heonilp, ParkJiwoon, syureu
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: 
 labels: enhancement
-assignees: goodGid, ParkJiwoon, syureu, DolphaGo, heonilp, AndoneKwon, bjh7013
+assignees: goodGid, ParkJiwoon, syureu, DolphaGo, heonilp, AndoneKwon
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -3,7 +3,7 @@ name: Question
 about: Ask us what you are curious about.
 title: 
 labels: question
-assignees: AndoneKwon, bjh7013, DolphaGo, goodGid, heonilp, ParkJiwoon, syureu
+assignees: AndoneKwon, DolphaGo, goodGid, heonilp, ParkJiwoon, syureu
 
 ---
 

--- a/src/main/java/our/yurivongella/instagramclone/config/JwtSecurityConfig.java
+++ b/src/main/java/our/yurivongella/instagramclone/config/JwtSecurityConfig.java
@@ -1,10 +1,12 @@
 package our.yurivongella.instagramclone.config;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.web.DefaultSecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
 import our.yurivongella.instagramclone.jwt.JwtFilter;
 import our.yurivongella.instagramclone.jwt.TokenProvider;
 

--- a/src/main/java/our/yurivongella/instagramclone/config/SecurityConfig.java
+++ b/src/main/java/our/yurivongella/instagramclone/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package our.yurivongella.instagramclone.config;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -70,7 +71,6 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/auth/**").permitAll()
             .anyRequest().authenticated()   // 나머지 API 는 전부 인증 필요
-
 
             // JwtFilter 를 addFilterBefore 로 등록했던 JwtSecurityConfig 클래스를 적용
             .and()

--- a/src/main/java/our/yurivongella/instagramclone/config/SwaggerConfig.java
+++ b/src/main/java/our/yurivongella/instagramclone/config/SwaggerConfig.java
@@ -1,6 +1,7 @@
 package our.yurivongella.instagramclone.config;
 
 import springfox.documentation.service.Parameter;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -29,11 +30,11 @@ public class SwaggerConfig {
     public Docket api() {
         ParameterBuilder parameterBuilder = new ParameterBuilder();
         parameterBuilder.name("Authorization") //헤더 이름
-                .description("Access Tocken") //설명
-                .modelRef(new ModelRef("string"))
-                .parameterType("header")
-                .required(false)
-                .build();
+                        .description("Access Tocken") //설명
+                        .modelRef(new ModelRef("string"))
+                        .parameterType("header")
+                        .required(false)
+                        .build();
 
         List<Parameter> parameters = new ArrayList<>();
         parameters.add(parameterBuilder.build());

--- a/src/main/java/our/yurivongella/instagramclone/controller/AuthController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/AuthController.java
@@ -2,12 +2,14 @@ package our.yurivongella.instagramclone.controller;
 
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
 import our.yurivongella.instagramclone.controller.dto.SigninRequestDto;
 import our.yurivongella.instagramclone.controller.dto.TokenDto;
 import our.yurivongella.instagramclone.controller.dto.SignupRequestDto;

--- a/src/main/java/our/yurivongella/instagramclone/controller/CommentController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/CommentController.java
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import io.swagger.annotations.ApiOperation;

--- a/src/main/java/our/yurivongella/instagramclone/controller/FeedController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/FeedController.java
@@ -1,6 +1,7 @@
 package our.yurivongella.instagramclone.controller;
 
 import io.swagger.annotations.ApiOperation;
+
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/our/yurivongella/instagramclone/controller/MemberController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/MemberController.java
@@ -3,6 +3,7 @@ package our.yurivongella.instagramclone.controller;
 import java.util.List;
 
 import io.swagger.annotations.ApiOperation;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 

--- a/src/main/java/our/yurivongella/instagramclone/controller/MemberController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/MemberController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import lombok.RequiredArgsConstructor;
-import our.yurivongella.instagramclone.controller.dto.FollowRequestDto;
 import our.yurivongella.instagramclone.controller.dto.MemberResponseDto;
 import our.yurivongella.instagramclone.service.MemberService;
 
@@ -18,16 +17,16 @@ public class MemberController {
     private final MemberService memberService;
 
     @ApiOperation("상대방 팔로우")
-    @PutMapping("/follow/{memberId}")
-    public ResponseEntity<String> follow(@PathVariable Long memberId) {
-        boolean success = memberService.follow(memberId);
+    @PutMapping("/follow/{displayId}")
+    public ResponseEntity<String> follow(@PathVariable String displayId) {
+        boolean success = memberService.follow(displayId);
         return ResponseEntity.ok("팔로우 결과: " + success);
     }
 
     @ApiOperation("상대방 언팔로우")
-    @DeleteMapping("/follow/{memberId}")
-    public ResponseEntity<String> unfollow(@PathVariable Long memberId) {
-        boolean success = memberService.unFollow(memberId);
+    @DeleteMapping("/follow/{displayId}")
+    public ResponseEntity<String> unfollow(@PathVariable String displayId) {
+        boolean success = memberService.unFollow(displayId);
         return ResponseEntity.ok("언팔로우 결과: " + success);
     }
 

--- a/src/main/java/our/yurivongella/instagramclone/controller/PostController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/PostController.java
@@ -46,4 +46,16 @@ public class PostController {
     public ResponseEntity<?> readPostList(@PathVariable Long memberId) {
         return ResponseEntity.ok(postService.getPostList(memberId));
     }
+
+    @ApiOperation("포스트 좋아요")
+    @PutMapping("/posts/{postId}/like")
+    public ResponseEntity<?> likePost(@PathVariable("postId") Long postId){
+        return ResponseEntity.ok(postService.likePost(postId));
+    }
+
+    @ApiOperation("포스트 좋아요 취소")
+    @DeleteMapping("/posts/{postId}/like")
+    public ResponseEntity<?> unLikePost(@PathVariable("postId") Long postId){
+        return ResponseEntity.ok(postService.unlikePost(postId));
+    }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/PostController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/PostController.java
@@ -42,9 +42,9 @@ public class PostController {
     }
 
     @ApiOperation("특정 사용자의 게시글 리스트 조회")
-    @GetMapping("/members/{memberId}/posts")
-    public ResponseEntity<?> readPostList(@PathVariable Long memberId) {
-        return ResponseEntity.ok(postService.getPostList(memberId));
+    @GetMapping("/members/{displayId}/posts")
+    public ResponseEntity<?> readPostList(@PathVariable String displayId) {
+        return ResponseEntity.ok(postService.getPostList(displayId));
     }
 
     @ApiOperation("포스트 좋아요")

--- a/src/main/java/our/yurivongella/instagramclone/controller/PostController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/PostController.java
@@ -2,8 +2,10 @@ package our.yurivongella.instagramclone.controller;
 
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
 import our.yurivongella.instagramclone.controller.dto.comment.ProcessStatus;
 import our.yurivongella.instagramclone.controller.dto.post.PostCreateRequestDto;
 import our.yurivongella.instagramclone.controller.dto.post.PostReadResponseDto;
@@ -49,13 +51,13 @@ public class PostController {
 
     @ApiOperation("포스트 좋아요")
     @PutMapping("/posts/{postId}/like")
-    public ResponseEntity<?> likePost(@PathVariable("postId") Long postId){
+    public ResponseEntity<?> likePost(@PathVariable("postId") Long postId) {
         return ResponseEntity.ok(postService.likePost(postId));
     }
 
     @ApiOperation("포스트 좋아요 취소")
     @DeleteMapping("/posts/{postId}/like")
-    public ResponseEntity<?> unLikePost(@PathVariable("postId") Long postId){
+    public ResponseEntity<?> unLikePost(@PathVariable("postId") Long postId) {
         return ResponseEntity.ok(postService.unlikePost(postId));
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/MemberResponseDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/MemberResponseDto.java
@@ -20,9 +20,9 @@ public class MemberResponseDto {
 
     public static MemberResponseDto of(Member member) {
         return MemberResponseDto.builder()
-                .displayId(member.getDisplayId())
-                .nickname(member.getNickname())
-                .profileImageUrl(member.getProfileImageUrl())
-                .build();
+                                .displayId(member.getDisplayId())
+                                .nickname(member.getNickname())
+                                .profileImageUrl(member.getProfileImageUrl())
+                                .build();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/MemberResponseDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/MemberResponseDto.java
@@ -13,25 +13,16 @@ import our.yurivongella.instagramclone.domain.member.Member;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MemberResponseDto {
-
-    private Long id;
-
     @NotNull
     private String displayId;
-
-    @NotNull
-    private String email;
-
     private String nickname;
     private String profileImageUrl;
 
     public static MemberResponseDto of(Member member) {
         return MemberResponseDto.builder()
-                                .id(member.getId())
-                                .displayId(member.getDisplayId())
-                                .email(member.getEmail())
-                                .nickname(member.getNickname())
-                                .profileImageUrl(member.getProfileImageUrl())
-                                .build();
+                .displayId(member.getDisplayId())
+                .nickname(member.getNickname())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/SigninRequestDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/SigninRequestDto.java
@@ -1,10 +1,12 @@
 package our.yurivongella.instagramclone.controller.dto;
 
 import com.sun.istack.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 
 @Getter

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/SignupRequestDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/SignupRequestDto.java
@@ -1,11 +1,14 @@
 package our.yurivongella.instagramclone.controller.dto;
 
 import com.sun.istack.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 import org.springframework.security.crypto.password.PasswordEncoder;
+
 import our.yurivongella.instagramclone.domain.member.Member;
 
 @Getter
@@ -27,10 +30,10 @@ public class SignupRequestDto {
 
     public Member toMember(PasswordEncoder passwordEncoder) {
         return Member.builder()
-                .displayId(displayId)
-                .email(email)
-                .password(passwordEncoder.encode(password))
-                .nickname(nickname)
-                .build();
+                     .displayId(displayId)
+                     .email(email)
+                     .password(passwordEncoder.encode(password))
+                     .nickname(nickname)
+                     .build();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/TokenRequestDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/TokenRequestDto.java
@@ -1,6 +1,7 @@
 package our.yurivongella.instagramclone.controller.dto;
 
 import com.sun.istack.NotNull;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/ProcessStatus.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/ProcessStatus.java
@@ -3,6 +3,7 @@ package our.yurivongella.instagramclone.controller.dto.comment;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
+
 import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/ProcessStatus.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/ProcessStatus.java
@@ -2,13 +2,16 @@ package our.yurivongella.instagramclone.controller.dto.comment;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
+import org.springframework.http.HttpStatus;
 
 @AllArgsConstructor
+@ToString
 @Getter
 public enum ProcessStatus {
-    SUCCESS("정상적으로 처리되었습니다."),
-    FAIL("정상적으로 처리가 되지 않았습니다.")
-    ;
+    SUCCESS(HttpStatus.OK, "정상적으로 처리되었습니다."),
+    FAIL(HttpStatus.BAD_REQUEST, "정상적으로 처리가 되지 않았습니다.");
 
+    private HttpStatus status;
     private String message;
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/post/CommentResponseDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/post/CommentResponseDto.java
@@ -1,6 +1,7 @@
 package our.yurivongella.instagramclone.controller.dto.post;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/post/CommentResponseDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/post/CommentResponseDto.java
@@ -16,13 +16,13 @@ public class CommentResponseDto {
     private MemberDto author;
     private Boolean isLike;
     @JsonProperty("likeLength")
-    private Integer likeCount;
+    private Long likeCount;
     //Long replyLength;
     private LocalDateTime created;
     private String content;
 
     @Builder
-    public CommentResponseDto(Long id, MemberDto author, Boolean isLike, Integer likeCount, LocalDateTime created, String content) {
+    public CommentResponseDto(Long id, MemberDto author, Boolean isLike, Long likeCount, LocalDateTime created, String content) {
         this.id = id;
         this.author = author;
         this.isLike = isLike;
@@ -36,7 +36,7 @@ public class CommentResponseDto {
                 .id(comment.getId())
                 .author(MemberDto.of(comment.getMember(), member))
                 .isLike(member.getCommentLikes().stream().anyMatch(v -> v.getComment().getId().equals(comment.getId())))
-                .likeCount(comment.getCommentLikes().size())
+                .likeCount(comment.getLikeCount())
                 .created(comment.getCreatedDate())
                 .content(comment.getContent())
                 .build();

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/post/MemberDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/post/MemberDto.java
@@ -8,14 +8,12 @@ import our.yurivongella.instagramclone.domain.member.Member;
 @Getter
 @NoArgsConstructor
 public class MemberDto {
-    Long id;
     String displayId;
     String profileImageUrl;
     Boolean isFollowedByMe;
 
     @Builder
-    public MemberDto(Long id, String displayId, String profileImageUrl, Boolean isFollowedByMe) {
-        this.id = id;
+    public MemberDto(String displayId, String profileImageUrl, Boolean isFollowedByMe) {
         this.displayId = displayId;
         this.profileImageUrl = profileImageUrl;
         this.isFollowedByMe = isFollowedByMe;
@@ -23,7 +21,6 @@ public class MemberDto {
 
     public static MemberDto of(Member other, Member currentMember) {
         return builder()
-                .id(other.getId())
                 .displayId(other.getDisplayId())
                 .profileImageUrl(other.getProfileImageUrl())
                 .isFollowedByMe(other.isFollowedBy(currentMember))

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/post/PostCreateRequestDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/post/PostCreateRequestDto.java
@@ -20,15 +20,15 @@ public class PostCreateRequestDto {
 
     public Post toPost(Member member) {
         return Post.builder()
-                .content(content)
-                .build()
-                .addMember(member);
+                   .content(content)
+                   .build()
+                   .addMember(member);
     }
 
     public List<MediaUrl> getMediaUrls(Post post) {
         return mediaUrls.stream().map(url -> MediaUrl.builder()
-                .url(url)
-                .post(post)
-                .build()).collect(Collectors.toList());
+                                                     .url(url)
+                                                     .post(post)
+                                                     .build()).collect(Collectors.toList());
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/post/PostReadResponseDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/post/PostReadResponseDto.java
@@ -1,14 +1,9 @@
 package our.yurivongella.instagramclone.controller.dto.post;
 
 import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
-import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.apache.commons.lang3.time.DateFormatUtils;
-import org.apache.commons.lang3.time.DateUtils;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -70,18 +65,18 @@ public class PostReadResponseDto {
 
     public static PostReadResponseDto of(Post post, Member member) {
         return PostReadResponseDto.builder()
-                                  .id(post.getId())
-                                  .author(MemberDto.of(post.getMember(), member))
-                                  .mediaUrls(post.getMediaUrls().stream().map(MediaUrl::getUrl).collect(Collectors.toList()))
-                                  .content(post.getContent())
-                                  .isLike(post.getPostLikes().stream().anyMatch(v -> v.getMember().getId().equals(member.getId())))
-                                  .usersWhoLike(post.getPostLikes().stream().findFirst().map(v -> MemberDto.of(v.getMember(), member)).orElse(null))
-                                  .likeCount(post.getPostLikes().size())
-                                  .commentCount(post.getComments().size())
-                                  .viewCount(post.getViews())
-                                  .createdAt(from(post.getCreatedDate()))
-                                  .modifiedAt(from(post.getModifiedDate()))
-                                  .build();
+                .id(post.getId())
+                .author(MemberDto.of(post.getMember(), member))
+                .mediaUrls(post.getMediaUrls().stream().map(MediaUrl::getUrl).collect(Collectors.toList()))
+                .content(post.getContent())
+                .isLike(post.getPostLikes().stream().anyMatch(v -> v.getMember().getId().equals(member.getId())))
+                .usersWhoLike(post.getPostLikes().stream().findFirst().map(v -> MemberDto.of(v.getMember(), member)).orElse(null))
+                .likeCount(post.getPostLikes().size())
+                .commentCount(post.getComments().size())
+                .viewCount(post.getViews())
+                .createdAt(from(post.getCreatedDate()))
+                .modifiedAt(from(post.getModifiedDate()))
+                .build();
     }
 
     private static String from(LocalDateTime time) {

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/post/PostReadResponseDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/post/PostReadResponseDto.java
@@ -65,18 +65,18 @@ public class PostReadResponseDto {
 
     public static PostReadResponseDto of(Post post, Member member) {
         return PostReadResponseDto.builder()
-                .id(post.getId())
-                .author(MemberDto.of(post.getMember(), member))
-                .mediaUrls(post.getMediaUrls().stream().map(MediaUrl::getUrl).collect(Collectors.toList()))
-                .content(post.getContent())
-                .isLike(post.getPostLikes().stream().anyMatch(v -> v.getMember().getId().equals(member.getId())))
-                .usersWhoLike(post.getPostLikes().stream().findFirst().map(v -> MemberDto.of(v.getMember(), member)).orElse(null))
-                .likeCount(post.getPostLikes().size())
-                .commentCount(post.getComments().size())
-                .viewCount(post.getViews())
-                .createdAt(from(post.getCreatedDate()))
-                .modifiedAt(from(post.getModifiedDate()))
-                .build();
+                                  .id(post.getId())
+                                  .author(MemberDto.of(post.getMember(), member))
+                                  .mediaUrls(post.getMediaUrls().stream().map(MediaUrl::getUrl).collect(Collectors.toList()))
+                                  .content(post.getContent())
+                                  .isLike(post.getPostLikes().stream().anyMatch(v -> v.getMember().getId().equals(member.getId())))
+                                  .usersWhoLike(post.getPostLikes().stream().findFirst().map(v -> MemberDto.of(v.getMember(), member)).orElse(null))
+                                  .likeCount(post.getPostLikes().size())
+                                  .commentCount(post.getComments().size())
+                                  .viewCount(post.getViews())
+                                  .createdAt(from(post.getCreatedDate()))
+                                  .modifiedAt(from(post.getModifiedDate()))
+                                  .build();
     }
 
     private static String from(LocalDateTime time) {

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
@@ -65,7 +65,7 @@ public class Comment extends BaseEntity {
     }
 
     public void unlike() {
-        if (this.likeCount <= 0) throw new CustomException(ErrorCode.INVALID_STATUS);
+        if (this.likeCount <= 0) { throw new CustomException(ErrorCode.INVALID_STATUS); }
         this.likeCount -= 1;
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
@@ -20,6 +20,8 @@ import lombok.NoArgsConstructor;
 import our.yurivongella.instagramclone.domain.BaseEntity;
 import our.yurivongella.instagramclone.domain.member.Member;
 import our.yurivongella.instagramclone.domain.post.Post;
+import our.yurivongella.instagramclone.exception.CustomException;
+import our.yurivongella.instagramclone.exception.ErrorCode;
 
 @Table(name = "comment")
 @Getter
@@ -45,6 +47,9 @@ public class Comment extends BaseEntity {
     @OneToMany(mappedBy = "comment", cascade = CascadeType.REMOVE)
     private Set<CommentLike> commentLikes = new HashSet<>();
 
+    @Column(name = "comment_like_count", columnDefinition = "long default 0")
+    private Long likeCount;
+
     public Comment create(Member member, Post post, String content) {
         this.member = member;
         this.post = post;
@@ -52,5 +57,14 @@ public class Comment extends BaseEntity {
         member.getComments().add(this);
         post.getComments().add(this);
         return this;
+    }
+
+    public void like(){
+        this.likeCount+=1;
+    }
+
+    public void unlike(){
+        if(this.likeCount<=0) throw new CustomException(ErrorCode.INVALID_STATUS);
+        this.likeCount-=1;
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
@@ -60,11 +60,11 @@ public class Comment extends BaseEntity {
         return this;
     }
 
-    public void like() {
+    public void plusLikeCount() {
         this.likeCount += 1;
     }
 
-    public void unlike() {
+    public void minusLikeCount() {
         if (this.likeCount <= 0) { throw new CustomException(ErrorCode.INVALID_STATUS); }
         this.likeCount -= 1;
     }

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/Comment.java
@@ -54,17 +54,18 @@ public class Comment extends BaseEntity {
         this.member = member;
         this.post = post;
         this.content = content;
+        this.likeCount = 0L;
         member.getComments().add(this);
         post.getComments().add(this);
         return this;
     }
 
-    public void like(){
-        this.likeCount+=1;
+    public void like() {
+        this.likeCount += 1;
     }
 
-    public void unlike(){
-        if(this.likeCount<=0) throw new CustomException(ErrorCode.INVALID_STATUS);
-        this.likeCount-=1;
+    public void unlike() {
+        if (this.likeCount <= 0) throw new CustomException(ErrorCode.INVALID_STATUS);
+        this.likeCount -= 1;
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLike.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLike.java
@@ -15,6 +15,8 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import our.yurivongella.instagramclone.domain.BaseEntity;
 import our.yurivongella.instagramclone.domain.member.Member;
+import our.yurivongella.instagramclone.exception.CustomException;
+import our.yurivongella.instagramclone.exception.ErrorCode;
 
 @NoArgsConstructor
 @Getter
@@ -39,10 +41,12 @@ public class CommentLike extends BaseEntity {
         this.member = member;
         this.comment = comment;
         comment.getCommentLikes().add(this);
+        comment.like();
         return this;
     }
 
     public void unlike() {
         comment.getCommentLikes().remove(this);
+        comment.unlike();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLike.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLike.java
@@ -15,8 +15,6 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 import our.yurivongella.instagramclone.domain.BaseEntity;
 import our.yurivongella.instagramclone.domain.member.Member;
-import our.yurivongella.instagramclone.exception.CustomException;
-import our.yurivongella.instagramclone.exception.ErrorCode;
 
 @NoArgsConstructor
 @Getter

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLike.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLike.java
@@ -39,12 +39,12 @@ public class CommentLike extends BaseEntity {
         this.member = member;
         this.comment = comment;
         comment.getCommentLikes().add(this);
-        comment.like();
+        comment.plusLikeCount();
         return this;
     }
 
     public void unlike() {
         comment.getCommentLikes().remove(this);
-        comment.unlike();
+        comment.minusLikeCount();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLikeRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentLikeRepository.java
@@ -1,10 +1,10 @@
 package our.yurivongella.instagramclone.domain.comment;
 
-import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
 
-    List<CommentLike> findAllByCommentId(Long commentId);
+    Optional<CommentLike> findByCommentIdAndMemberId(Long commentId, Long memberId);
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/comment/CommentRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import our.yurivongella.instagramclone.domain.member.Member;
 import our.yurivongella.instagramclone.domain.post.Post;
 

--- a/src/main/java/our/yurivongella/instagramclone/domain/follow/Follow.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/follow/Follow.java
@@ -13,7 +13,7 @@ import our.yurivongella.instagramclone.domain.member.Member;
 @NoArgsConstructor
 @Table(
         name = "follow",
-        uniqueConstraints = {@UniqueConstraint(columnNames = { "from_member_id", "to_member_id" })}
+        uniqueConstraints = { @UniqueConstraint(columnNames = { "from_member_id", "to_member_id" }) }
 )
 public class Follow extends BaseEntity {
 

--- a/src/main/java/our/yurivongella/instagramclone/domain/follow/FollowRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/follow/FollowRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface FollowRepository extends JpaRepository<Follow,Long> {
+public interface FollowRepository extends JpaRepository<Follow, Long> {
     List<Follow> findByFromMemberId(Long id);
 
     List<Follow> findByToMemberId(Long id);

--- a/src/main/java/our/yurivongella/instagramclone/domain/member/Member.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/member/Member.java
@@ -24,7 +24,7 @@ import our.yurivongella.instagramclone.domain.post.PostLike;
 @Entity
 @NoArgsConstructor
 @Table(name = "member")
-@ToString(of = {"displayId","email"})
+@ToString(of = { "displayId", "email" })
 public class Member extends BaseEntity {
 
     @Id
@@ -91,14 +91,14 @@ public class Member extends BaseEntity {
 
     public boolean isFollowingTo(Member other) {
         return followings.stream()
-                .map(Follow::getToMember)
-                .anyMatch(toMember -> toMember.equals(other));
+                         .map(Follow::getToMember)
+                         .anyMatch(toMember -> toMember.equals(other));
     }
 
     public boolean isFollowedBy(Member other) {
         return followers.stream()
-                .map(Follow::getFromMember)
-                .anyMatch(fromMember -> fromMember.equals(other));
+                        .map(Follow::getFromMember)
+                        .anyMatch(fromMember -> fromMember.equals(other));
     }
 
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/member/MemberRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/member/MemberRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+    Optional<Member> findByDisplayId(String displayId);
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/member/MemberRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/member/MemberRepository.java
@@ -6,5 +6,6 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByEmail(String email);
+
     Optional<Member> findByDisplayId(String displayId);
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/MediaUrl.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/MediaUrl.java
@@ -51,8 +51,8 @@ public class MediaUrl extends BaseEntity {
         this.url = url;
         this.post = post;
         this.mediaUrlType = extensions.stream().anyMatch(url::endsWith)
-                ? MediaUrlType.IMAGE
-                : MediaUrlType.VIDEO;
+                            ? MediaUrlType.IMAGE
+                            : MediaUrlType.VIDEO;
     }
 
     private enum MediaUrlType {

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
@@ -21,6 +21,8 @@ import org.hibernate.annotations.Cascade;
 import our.yurivongella.instagramclone.domain.BaseEntity;
 import our.yurivongella.instagramclone.domain.comment.Comment;
 import our.yurivongella.instagramclone.domain.member.Member;
+import our.yurivongella.instagramclone.exception.CustomException;
+import our.yurivongella.instagramclone.exception.ErrorCode;
 
 @Getter
 @NoArgsConstructor
@@ -39,7 +41,11 @@ public class Post extends BaseEntity {
     @Column(columnDefinition = "text")
     private String content;
 
+    @Column(name = "views", columnDefinition = "long default 0")
     private Long views;
+
+    @Column(name = "post_like_count", columnDefinition = "long default 0")
+    private Long likeCount;
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.REMOVE)
     List<MediaUrl> mediaUrls = new ArrayList<>();
@@ -53,11 +59,25 @@ public class Post extends BaseEntity {
     @Builder
     public Post(String content) {
         this.content = content;
+        this.likeCount = 0L;
     }
 
     public Post addMember(Member member) {
         this.member = member;
         member.getPosts().add(this);
         return this;
+    }
+
+    public void like() {
+        this.likeCount += 1;
+    }
+
+    public void unlike() {
+        if (this.likeCount <= 0) throw new CustomException(ErrorCode.INVALID_STATUS);
+        this.likeCount -= 1;
+    }
+
+    public void viewCountUp() {
+        this.views += 1;
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
@@ -60,6 +60,7 @@ public class Post extends BaseEntity {
     public Post(String content) {
         this.content = content;
         this.likeCount = 0L;
+        this.views = 0L;
     }
 
     public Post addMember(Member member) {

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
@@ -69,11 +69,11 @@ public class Post extends BaseEntity {
         return this;
     }
 
-    public void like() {
+    public void plusLikeCount() {
         this.likeCount += 1;
     }
 
-    public void unlike() {
+    public void minusLikeCount() {
         if (this.likeCount <= 0) { throw new CustomException(ErrorCode.INVALID_STATUS); }
         this.likeCount -= 1;
     }

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/Post.java
@@ -17,7 +17,7 @@ import javax.persistence.OneToMany;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.hibernate.annotations.Cascade;
+
 import our.yurivongella.instagramclone.domain.BaseEntity;
 import our.yurivongella.instagramclone.domain.comment.Comment;
 import our.yurivongella.instagramclone.domain.member.Member;
@@ -74,7 +74,7 @@ public class Post extends BaseEntity {
     }
 
     public void unlike() {
-        if (this.likeCount <= 0) throw new CustomException(ErrorCode.INVALID_STATUS);
+        if (this.likeCount <= 0) { throw new CustomException(ErrorCode.INVALID_STATUS); }
         this.likeCount -= 1;
     }
 

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/PostLike.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/PostLike.java
@@ -37,13 +37,13 @@ public class PostLike extends BaseEntity {
         this.member = member;
         this.post = post;
         post.getPostLikes().add(this);
-        post.like();
+        post.plusLikeCount();
         return this;
     }
 
     public void unlike() {
         post.getPostLikes().remove(this);
-        post.unlike();
+        post.minusLikeCount();
     }
 
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/PostLike.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/PostLike.java
@@ -13,7 +13,11 @@ import javax.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import our.yurivongella.instagramclone.domain.BaseEntity;
+import our.yurivongella.instagramclone.domain.comment.Comment;
+import our.yurivongella.instagramclone.domain.comment.CommentLike;
 import our.yurivongella.instagramclone.domain.member.Member;
+import our.yurivongella.instagramclone.exception.CustomException;
+import our.yurivongella.instagramclone.exception.ErrorCode;
 
 @Getter
 @Entity
@@ -33,5 +37,17 @@ public class PostLike extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
+    public PostLike like(Member member, Post post) {
+        this.member = member;
+        this.post = post;
+        post.getPostLikes().add(this);
+        post.like();
+        return this;
+    }
+
+    public void unlike() {
+        post.getPostLikes().remove(this);
+        post.unlike();
+    }
 
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/PostLike.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/PostLike.java
@@ -13,11 +13,7 @@ import javax.persistence.Table;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import our.yurivongella.instagramclone.domain.BaseEntity;
-import our.yurivongella.instagramclone.domain.comment.Comment;
-import our.yurivongella.instagramclone.domain.comment.CommentLike;
 import our.yurivongella.instagramclone.domain.member.Member;
-import our.yurivongella.instagramclone.exception.CustomException;
-import our.yurivongella.instagramclone.exception.ErrorCode;
 
 @Getter
 @Entity

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/PostLikeRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/PostLikeRepository.java
@@ -1,6 +1,10 @@
 package our.yurivongella.instagramclone.domain.post;
 
+import net.bytebuddy.asm.TypeReferenceAdjustment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findByPostIdAndMemberId(Long memberId, Long postId);
 }

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/PostLikeRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/PostLikeRepository.java
@@ -1,6 +1,5 @@
 package our.yurivongella.instagramclone.domain.post;
 
-import net.bytebuddy.asm.TypeReferenceAdjustment;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;

--- a/src/main/java/our/yurivongella/instagramclone/domain/post/PostRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/domain/post/PostRepository.java
@@ -11,9 +11,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByMemberId(Long memberId);
 
     @Query(value = "SELECT p" +
-            " FROM Post p" +
-            " JOIN Follow f" +
-            " ON p.member.id = f.toMember.id" +
-            " WHERE f.fromMember.id = :memberId AND p.id < :lastPostId")
+                   " FROM Post p" +
+                   " JOIN Follow f" +
+                   " ON p.member.id = f.toMember.id" +
+                   " WHERE f.fromMember.id = :memberId AND p.id < :lastPostId")
     List<Post> findAllByJoinFollow(@Param("memberId") Long memberId, @Param("lastPostId") Long lastPostId, Pageable pageable);
 }

--- a/src/main/java/our/yurivongella/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/our/yurivongella/instagramclone/exception/ErrorCode.java
@@ -2,6 +2,7 @@ package our.yurivongella.instagramclone.exception;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+
 import org.springframework.http.HttpStatus;
 
 import static org.springframework.http.HttpStatus.*;
@@ -25,15 +26,13 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(NOT_FOUND, "해당 유저 정보를 찾을 수 없습니다"),
     REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "로그아웃 된 사용자입니다"),
     NOT_FOLLOW(NOT_FOUND, "팔로우 중이지 않습니다"),
-    POST_NOT_FOUND(NOT_FOUND,"해당 포스트가 존재하지 않습니다."),
+    POST_NOT_FOUND(NOT_FOUND, "해당 포스트가 존재하지 않습니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(CONFLICT, "데이터가 이미 존재합니다"),
 
     /* 서버 내 데이터 오류 */
-    INVALID_STATUS(INTERNAL_SERVER_ERROR,"서버 내 데이터에 오류가 있습니다")
-
-    ;
+    INVALID_STATUS(INTERNAL_SERVER_ERROR, "서버 내 데이터에 오류가 있습니다");
 
     private final HttpStatus httpStatus;
     private final String detail;

--- a/src/main/java/our/yurivongella/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/our/yurivongella/instagramclone/exception/ErrorCode.java
@@ -15,8 +15,6 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "리프레시 토큰이 유효하지 않습니다"),
     MISMATCH_REFRESH_TOKEN(BAD_REQUEST, "리프레시 토큰의 유저 정보가 일치하지 않습니다"),
     CANNOT_FOLLOW_MYSELF(BAD_REQUEST, "자기 자신은 팔로우 할 수 없습니다"),
-    ALREADY_LIKE(BAD_REQUEST, "더 이상 좋아요를 할 수 없습니다"),
-    ALREADY_UNLIKE(BAD_REQUEST, "더 이상 좋아요를 취소할 수 없습니다"),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
     INVALID_AUTH_TOKEN(UNAUTHORIZED, "권한 정보가 없는 토큰입니다"),
@@ -27,9 +25,11 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "로그아웃 된 사용자입니다"),
     NOT_FOLLOW(NOT_FOUND, "팔로우 중이지 않습니다"),
     POST_NOT_FOUND(NOT_FOUND, "해당 포스트가 존재하지 않습니다."),
+    ALREADY_UNLIKE(NOT_FOUND, "더 이상 좋아요를 취소할 수 없습니다"),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(CONFLICT, "데이터가 이미 존재합니다"),
+    ALREADY_LIKE(CONFLICT, "더 이상 좋아요를 할 수 없습니다"),
 
     /* 서버 내 데이터 오류 */
     INVALID_STATUS(INTERNAL_SERVER_ERROR, "서버 내 데이터에 오류가 있습니다");

--- a/src/main/java/our/yurivongella/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/our/yurivongella/instagramclone/exception/ErrorCode.java
@@ -14,6 +14,8 @@ public enum ErrorCode {
     INVALID_REFRESH_TOKEN(BAD_REQUEST, "리프레시 토큰이 유효하지 않습니다"),
     MISMATCH_REFRESH_TOKEN(BAD_REQUEST, "리프레시 토큰의 유저 정보가 일치하지 않습니다"),
     CANNOT_FOLLOW_MYSELF(BAD_REQUEST, "자기 자신은 팔로우 할 수 없습니다"),
+    ALREADY_LIKE(BAD_REQUEST, "더 이상 좋아요를 할 수 없습니다"),
+    ALREADY_UNLIKE(BAD_REQUEST, "더 이상 좋아요를 취소할 수 없습니다"),
 
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
     INVALID_AUTH_TOKEN(UNAUTHORIZED, "권한 정보가 없는 토큰입니다"),
@@ -23,9 +25,13 @@ public enum ErrorCode {
     MEMBER_NOT_FOUND(NOT_FOUND, "해당 유저 정보를 찾을 수 없습니다"),
     REFRESH_TOKEN_NOT_FOUND(NOT_FOUND, "로그아웃 된 사용자입니다"),
     NOT_FOLLOW(NOT_FOUND, "팔로우 중이지 않습니다"),
+    POST_NOT_FOUND(NOT_FOUND,"해당 포스트가 존재하지 않습니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(CONFLICT, "데이터가 이미 존재합니다"),
+
+    /* 서버 내 데이터 오류 */
+    INVALID_STATUS(INTERNAL_SERVER_ERROR,"서버 내 데이터에 오류가 있습니다")
 
     ;
 

--- a/src/main/java/our/yurivongella/instagramclone/exception/ErrorCode.java
+++ b/src/main/java/our/yurivongella/instagramclone/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     NOT_FOLLOW(NOT_FOUND, "팔로우 중이지 않습니다"),
     POST_NOT_FOUND(NOT_FOUND, "해당 포스트가 존재하지 않습니다."),
     ALREADY_UNLIKE(NOT_FOUND, "더 이상 좋아요를 취소할 수 없습니다"),
+    COMMENT_NOT_FOUND(NOT_FOUND, "해당 댓글이 존재하지 않습니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(CONFLICT, "데이터가 이미 존재합니다"),

--- a/src/main/java/our/yurivongella/instagramclone/exception/ErrorResponse.java
+++ b/src/main/java/our/yurivongella/instagramclone/exception/ErrorResponse.java
@@ -2,6 +2,7 @@ package our.yurivongella.instagramclone.exception;
 
 import lombok.Builder;
 import lombok.Getter;
+
 import org.springframework.http.ResponseEntity;
 
 import java.time.LocalDateTime;
@@ -19,11 +20,11 @@ public class ErrorResponse {
         return ResponseEntity
                 .status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()
-                        .status(errorCode.getHttpStatus().value())
-                        .error(errorCode.getHttpStatus().name())
-                        .code(errorCode.name())
-                        .message(errorCode.getDetail())
-                        .build()
+                                   .status(errorCode.getHttpStatus().value())
+                                   .error(errorCode.getHttpStatus().name())
+                                   .code(errorCode.name())
+                                   .message(errorCode.getDetail())
+                                   .build()
                 );
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/exception/GlobalExceptionHandler.java
+++ b/src/main/java/our/yurivongella/instagramclone/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package our.yurivongella.instagramclone.exception;
 
 import lombok.extern.slf4j.Slf4j;
+
 import org.hibernate.exception.ConstraintViolationException;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.ResponseEntity;
@@ -14,7 +15,7 @@ import static our.yurivongella.instagramclone.exception.ErrorCode.*;
 @RestControllerAdvice
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
-    @ExceptionHandler(value = { ConstraintViolationException.class, DataIntegrityViolationException.class})
+    @ExceptionHandler(value = { ConstraintViolationException.class, DataIntegrityViolationException.class })
     protected ResponseEntity<ErrorResponse> handleDataException() {
         log.error("handleDataException throw Exception : {}", DUPLICATE_RESOURCE);
         return ErrorResponse.toResponseEntity(DUPLICATE_RESOURCE);

--- a/src/main/java/our/yurivongella/instagramclone/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/our/yurivongella/instagramclone/jwt/JwtAccessDeniedHandler.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Component;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 @Component

--- a/src/main/java/our/yurivongella/instagramclone/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/our/yurivongella/instagramclone/jwt/JwtAuthenticationEntryPoint.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import java.io.IOException;
 
 @Component

--- a/src/main/java/our/yurivongella/instagramclone/jwt/TokenProvider.java
+++ b/src/main/java/our/yurivongella/instagramclone/jwt/TokenProvider.java
@@ -28,7 +28,7 @@ import static our.yurivongella.instagramclone.exception.ErrorCode.*;
 @Component
 public class TokenProvider {
     private static final String AUTHORITIES_KEY = "auth";
-    private static final String BEARER_TYPE = "bearer";
+    private static final String BEARER_TYPE = "Bearer";
     private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30;            // 30분
     private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;  // 7일
 

--- a/src/main/java/our/yurivongella/instagramclone/jwt/TokenProvider.java
+++ b/src/main/java/our/yurivongella/instagramclone/jwt/TokenProvider.java
@@ -4,6 +4,7 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -12,6 +13,7 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
+
 import our.yurivongella.instagramclone.controller.dto.TokenDto;
 import our.yurivongella.instagramclone.exception.CustomException;
 import our.yurivongella.instagramclone.exception.ErrorCode;
@@ -42,32 +44,32 @@ public class TokenProvider {
     public TokenDto generateTokenDto(Authentication authentication) {
         // 권한들 가져오기
         String authorities = authentication.getAuthorities().stream()
-                .map(GrantedAuthority::getAuthority)
-                .collect(Collectors.joining(","));
+                                           .map(GrantedAuthority::getAuthority)
+                                           .collect(Collectors.joining(","));
 
         long now = (new Date()).getTime();
 
         // Access Token 생성
         Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
         String accessToken = Jwts.builder()
-                .setSubject(authentication.getName())       // payload "sub": "name"
-                .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
-                .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
-                .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
-                .compact();
+                                 .setSubject(authentication.getName())       // payload "sub": "name"
+                                 .claim(AUTHORITIES_KEY, authorities)        // payload "auth": "ROLE_USER"
+                                 .setExpiration(accessTokenExpiresIn)        // payload "exp": 1516239022 (예시)
+                                 .signWith(key, SignatureAlgorithm.HS512)    // header "alg": "HS512"
+                                 .compact();
 
         // Refresh Token 생성
         String refreshToken = Jwts.builder()
-                .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
-                .signWith(key, SignatureAlgorithm.HS512)
-                .compact();
+                                  .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))
+                                  .signWith(key, SignatureAlgorithm.HS512)
+                                  .compact();
 
         return TokenDto.builder()
-                .grantType(BEARER_TYPE)
-                .accessToken(accessToken)
-                .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
-                .refreshToken(refreshToken)
-                .build();
+                       .grantType(BEARER_TYPE)
+                       .accessToken(accessToken)
+                       .accessTokenExpiresIn(accessTokenExpiresIn.getTime())
+                       .refreshToken(refreshToken)
+                       .build();
     }
 
     public Authentication getAuthentication(String accessToken) {
@@ -81,8 +83,8 @@ public class TokenProvider {
         // 클레임에서 권한 정보 가져오기
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-                        .map(SimpleGrantedAuthority::new)
-                        .collect(Collectors.toList());
+                      .map(SimpleGrantedAuthority::new)
+                      .collect(Collectors.toList());
 
         // UserDetails 객체를 만들어서 Authentication 리턴
         UserDetails principal = new User(claims.getSubject(), "", authorities);

--- a/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/AuthService.java
@@ -1,12 +1,14 @@
 package our.yurivongella.instagramclone.service;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import our.yurivongella.instagramclone.controller.dto.SigninRequestDto;
 import our.yurivongella.instagramclone.controller.dto.SignupRequestDto;
 import our.yurivongella.instagramclone.controller.dto.TokenDto;
@@ -29,11 +31,11 @@ public class AuthService {
     private final MemberRepository memberRepository;
     private final RefreshTokenRepository refreshTokenRepository;
 
-@Transactional
-public String signup(SignupRequestDto signupRequestDto) {
-    Member member = signupRequestDto.toMember(passwordEncoder);
-    return memberRepository.save(member).getEmail();
-}
+    @Transactional
+    public String signup(SignupRequestDto signupRequestDto) {
+        Member member = signupRequestDto.toMember(passwordEncoder);
+        return memberRepository.save(member).getEmail();
+    }
 
     @Transactional
     public TokenDto signin(SigninRequestDto signinRequestDto) {
@@ -49,9 +51,9 @@ public String signup(SignupRequestDto signupRequestDto) {
 
         // 4. RefreshToken 저장
         RefreshToken refreshToken = RefreshToken.builder()
-                .key(authentication.getName())
-                .value(tokenDto.getRefreshToken())
-                .build();
+                                                .key(authentication.getName())
+                                                .value(tokenDto.getRefreshToken())
+                                                .build();
 
         refreshTokenRepository.save(refreshToken);
 
@@ -71,7 +73,7 @@ public String signup(SignupRequestDto signupRequestDto) {
 
         // 3. 저장소에서 Member ID 를 기반으로 Refresh Token 값 가져옴
         RefreshToken refreshToken = refreshTokenRepository.findByKey(authentication.getName())
-                .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_FOUND));
+                                                          .orElseThrow(() -> new CustomException(REFRESH_TOKEN_NOT_FOUND));
 
         // 4. Refresh Token 일치하는지 검사
         if (!refreshToken.getValue().equals(tokenRequestDto.getRefreshToken())) {

--- a/src/main/java/our/yurivongella/instagramclone/service/CommentService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/CommentService.java
@@ -2,6 +2,7 @@ package our.yurivongella.instagramclone.service;
 
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Service;
@@ -21,6 +22,8 @@ import our.yurivongella.instagramclone.domain.member.Member;
 import our.yurivongella.instagramclone.domain.member.MemberRepository;
 import our.yurivongella.instagramclone.domain.post.Post;
 import our.yurivongella.instagramclone.domain.post.PostRepository;
+import our.yurivongella.instagramclone.exception.CustomException;
+import our.yurivongella.instagramclone.exception.ErrorCode;
 import our.yurivongella.instagramclone.util.SecurityUtil;
 
 @Transactional(readOnly = true)
@@ -37,10 +40,10 @@ public class CommentService {
         Member member = getCurrentMember();
 
         return postRepository.findById(postId).orElseThrow(() -> new NoSuchElementException("해당 게시물이 없습니다."))
-                             .getComments()
-                             .stream()
-                             .map(c -> CommentResponseDto.of(c, member))
-                             .collect(Collectors.toList());
+                .getComments()
+                .stream()
+                .map(c -> CommentResponseDto.of(c, member))
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -48,7 +51,7 @@ public class CommentService {
         Member member = getCurrentMember();
 
         Post post = postRepository.findById(postId)
-                                  .orElseThrow(() -> new NoSuchElementException("해당 게시물이 없습니다."));
+                .orElseThrow(() -> new NoSuchElementException("해당 게시물이 없습니다."));
 
         Comment comment = new Comment();
         comment.create(member, post, commentCreateDto.getContent());
@@ -68,31 +71,33 @@ public class CommentService {
 
         try {
             commentRepository.deleteById(commentId);
-            return ProcessStatus.SUCCESS;
         } catch (Exception e) {
             log.error("삭제 도중 문제가 발생했습니다 = {}", e.getMessage());
+            return ProcessStatus.FAIL;
         }
-        return ProcessStatus.FAIL;
+        return ProcessStatus.SUCCESS;
     }
 
     @Transactional
     public ProcessStatus likeComment(Long commentId) throws Exception {
         Member member = getCurrentMember();
         Comment comment = getCurrentComment(commentId);
-
-        boolean check = commentLikeRepository.findAllByCommentId(commentId)
-                                             .stream()
-                                             .anyMatch(cl -> cl.getMember().equals(member));
-        if (!check) {
-            log.info("{}가 댓글 {}를 좋아요 표시합니다.", member.getDisplayId(), comment.getContent());
+        try {
             CommentLike commentLike = createCommentLike(member, comment);
+            log.info("{}가 댓글 {}를 좋아요 표시합니다.", member.getDisplayId(), comment.getContent());
             commentLikeRepository.save(commentLike);
-            return ProcessStatus.SUCCESS;
+        } catch (Exception e) {
+            log.error("[댓글 번호:{}] {}가 좋아요 도중 에러가 발생했습니다.", comment.getId(), member.getDisplayId());
+            throw e;
         }
-        return ProcessStatus.FAIL;
+        return ProcessStatus.SUCCESS;
     }
 
     private CommentLike createCommentLike(Member member, Comment comment) {
+        commentLikeRepository.findByCommentIdAndMemberId(comment.getId(), member.getId()).ifPresent(commentLike -> {
+            log.error("[댓글 번호:{}] {}가 이미 좋아요를 하고 있습니다.", comment.getId(), member.getId());
+            throw new CustomException(ErrorCode.ALREADY_LIKE);
+        });
         return new CommentLike().like(member, comment);
     }
 
@@ -100,26 +105,25 @@ public class CommentService {
     public ProcessStatus unlikeComment(Long commentId) throws Exception {
         Member member = getCurrentMember();
         Comment comment = getCurrentComment(commentId);
+        CommentLike commentLike = commentLikeRepository.findByCommentIdAndMemberId(commentId, member.getId()).orElseThrow(() -> new CustomException(ErrorCode.ALREADY_UNLIKE));
 
-        return commentLikeRepository.findAllByCommentId(commentId)
-                                    .stream()
-                                    .filter(cl -> cl.getMember().equals(member))
-                                    .findFirst()
-                                    .map(cl -> {
-                                        log.info("{}가 댓글 {}를 좋아요 취소합니다.", member.getDisplayId(), comment.getContent());
-                                        cl.unlike();
-                                        commentLikeRepository.delete(cl);
-                                        return ProcessStatus.SUCCESS;
-                                    }).orElse(ProcessStatus.FAIL);
+        try {
+            commentLike.unlike();
+            commentLikeRepository.delete(commentLike);
+        } catch (Exception e) {
+            log.error("[댓글 번호 : {}] {}가 좋아요 취소 도중 에러가 발생했습니다.", comment.getId(), member.getDisplayId());
+            return ProcessStatus.FAIL;
+        }
+        return ProcessStatus.SUCCESS;
     }
 
     private Member getCurrentMember() {
         return memberRepository.findById(SecurityUtil.getCurrentMemberId())
-                               .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
+                .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
     }
 
     private Comment getCurrentComment(Long commentId) throws NotFoundException {
         return commentRepository.findById(commentId)
-                                .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
+                .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/service/CommentService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/CommentService.java
@@ -40,10 +40,10 @@ public class CommentService {
         Member member = getCurrentMember();
 
         return postRepository.findById(postId).orElseThrow(() -> new NoSuchElementException("해당 게시물이 없습니다."))
-                .getComments()
-                .stream()
-                .map(c -> CommentResponseDto.of(c, member))
-                .collect(Collectors.toList());
+                             .getComments()
+                             .stream()
+                             .map(c -> CommentResponseDto.of(c, member))
+                             .collect(Collectors.toList());
     }
 
     @Transactional
@@ -51,7 +51,7 @@ public class CommentService {
         Member member = getCurrentMember();
 
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new NoSuchElementException("해당 게시물이 없습니다."));
+                                  .orElseThrow(() -> new NoSuchElementException("해당 게시물이 없습니다."));
 
         Comment comment = new Comment();
         comment.create(member, post, commentCreateDto.getContent());
@@ -119,11 +119,11 @@ public class CommentService {
 
     private Member getCurrentMember() {
         return memberRepository.findById(SecurityUtil.getCurrentMemberId())
-                .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
+                               .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
     }
 
     private Comment getCurrentComment(Long commentId) throws NotFoundException {
         return commentRepository.findById(commentId)
-                .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
+                                .orElseThrow(() -> new NotFoundException("존재하지 않는 댓글입니다."));
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/service/CustomUserDetailsService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/CustomUserDetailsService.java
@@ -1,6 +1,7 @@
 package our.yurivongella.instagramclone.service;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
@@ -9,6 +10,7 @@ import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
 import our.yurivongella.instagramclone.domain.member.Member;
 import our.yurivongella.instagramclone.domain.member.MemberRepository;
 
@@ -24,8 +26,8 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Transactional
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
         return memberRepository.findByEmail(username)
-                .map(this::createUserDetails)
-                .orElseThrow(() -> new UsernameNotFoundException(username + " -> 데이터베이스에서 찾을 수 없습니다."));
+                               .map(this::createUserDetails)
+                               .orElseThrow(() -> new UsernameNotFoundException(username + " -> 데이터베이스에서 찾을 수 없습니다."));
     }
 
     // DB 에 User 값이 존재한다면 userdetails.User 객체로 만들어서 리턴

--- a/src/main/java/our/yurivongella/instagramclone/service/MemberService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/MemberService.java
@@ -8,7 +8,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.transaction.annotation.Transactional;
+
 import lombok.extern.slf4j.Slf4j;
 import our.yurivongella.instagramclone.controller.dto.MemberResponseDto;
 import our.yurivongella.instagramclone.domain.follow.Follow;
@@ -36,9 +38,9 @@ public class MemberService {
         }
 
         Follow follow = Follow.builder()
-                .fromMember(currentMember)
-                .toMember(targetMember)
-                .build();
+                              .fromMember(currentMember)
+                              .toMember(targetMember)
+                              .build();
 
         followRepository.save(follow);
         return true;
@@ -51,8 +53,8 @@ public class MemberService {
                 SecurityUtil.getCurrentMemberId(),
                 targetMember.getId()
         )
-                .orElseThrow(() -> new CustomException(NOT_FOLLOW))
-                .unfollow();
+                                        .orElseThrow(() -> new CustomException(NOT_FOLLOW))
+                                        .unfollow();
 
         followRepository.delete(follow);
         return true;
@@ -64,13 +66,13 @@ public class MemberService {
         log.info("현재 자신의 follower를 알고 싶은 유저 = {}", currentMember.getDisplayId());
 
         return currentMember.getFollowers().stream()
-                .map(f -> {
-                    Member fromMember = f.getFromMember();
-                    log.info("{}를 팔로우 하는 유저 = {}", currentMember.getDisplayId(), fromMember.getDisplayId());
-                    return fromMember;
-                })
-                .map(MemberResponseDto::of)
-                .collect(Collectors.toList());
+                            .map(f -> {
+                                Member fromMember = f.getFromMember();
+                                log.info("{}를 팔로우 하는 유저 = {}", currentMember.getDisplayId(), fromMember.getDisplayId());
+                                return fromMember;
+                            })
+                            .map(MemberResponseDto::of)
+                            .collect(Collectors.toList());
     }
 
     @Transactional
@@ -78,13 +80,13 @@ public class MemberService {
         Member currentMember = getCurrentMember();
         log.info("현재 자신이 following 하고 있는 사람들을 알고 싶은 유저 = {}", currentMember.getDisplayId());
         return currentMember.getFollowings().stream()
-                .map(f -> {
-                    Member toMember = f.getToMember();
-                    log.info("{}가 {}를 팔로잉 하고 있습니다.", currentMember.getDisplayId(), toMember.getDisplayId());
-                    return toMember;
-                })
-                .map(MemberResponseDto::of)
-                .collect(Collectors.toList());
+                            .map(f -> {
+                                Member toMember = f.getToMember();
+                                log.info("{}가 {}를 팔로잉 하고 있습니다.", currentMember.getDisplayId(), toMember.getDisplayId());
+                                return toMember;
+                            })
+                            .map(MemberResponseDto::of)
+                            .collect(Collectors.toList());
     }
 
     /**
@@ -92,7 +94,7 @@ public class MemberService {
      */
     private Member getCurrentMember() {
         return memberRepository.findById(SecurityUtil.getCurrentMemberId())
-                .orElseThrow(() -> new CustomException(UNAUTHORIZED_MEMBER));
+                               .orElseThrow(() -> new CustomException(UNAUTHORIZED_MEMBER));
     }
 }
 

--- a/src/main/java/our/yurivongella/instagramclone/service/PostService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/PostService.java
@@ -56,8 +56,7 @@ public class PostService {
     @Transactional
     public PostReadResponseDto read(Long postId) {
         Member member = getCurrentMember();
-        Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("게시물이 없습니다."));
+        Post post = postRepository.findById(postId).orElseThrow(() -> new CustomException(ErrorCode.POST_NOT_FOUND));
         post.viewCountUp();
         return PostReadResponseDto.of(post, member);
     }
@@ -120,23 +119,22 @@ public class PostService {
         return new PostLike().like(member, post);
     }
 
-    public List<PostReadResponseDto> getPostList(Long memberId) {
-        Member member = getMember(memberId);
+    public List<PostReadResponseDto> getPostList(String displayId) {
+        Member member = getMemberByDisplayId(displayId);
 
         return member.getPosts().stream()
                 .map(post -> PostReadResponseDto.of(post, member))
                 .collect(Collectors.toList());
     }
 
-
     private Member getCurrentMember() {
         return memberRepository.findById(SecurityUtil.getCurrentMemberId())
                 .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
     }
 
-    private Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
+    private Member getMemberByDisplayId(String displayId) {
+        return memberRepository.findByDisplayId(displayId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
     /**

--- a/src/main/java/our/yurivongella/instagramclone/service/PostService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/PostService.java
@@ -64,7 +64,7 @@ public class PostService {
     @Transactional
     public ProcessStatus delete(@NotNull Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("게시물이 없습니다."));
+                                  .orElseThrow(() -> new RuntimeException("게시물이 없습니다."));
 
         if (!post.getMember().getId().equals(SecurityUtil.getCurrentMemberId())) {
             log.error("유저가 일치하지 않습니다.");
@@ -83,7 +83,7 @@ public class PostService {
     @Transactional
     public ProcessStatus likePost(@NotNull Long postId) {
         Post post = postRepository.findById(postId)
-                .orElseThrow(() -> new RuntimeException("게시물이 없습니다."));
+                                  .orElseThrow(() -> new RuntimeException("게시물이 없습니다."));
 
         try {
             Member member = getCurrentMember();
@@ -123,18 +123,18 @@ public class PostService {
         Member member = getMemberByDisplayId(displayId);
 
         return member.getPosts().stream()
-                .map(post -> PostReadResponseDto.of(post, member))
-                .collect(Collectors.toList());
+                     .map(post -> PostReadResponseDto.of(post, member))
+                     .collect(Collectors.toList());
     }
 
     private Member getCurrentMember() {
         return memberRepository.findById(SecurityUtil.getCurrentMemberId())
-                .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
+                               .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
     }
 
     private Member getMemberByDisplayId(String displayId) {
         return memberRepository.findByDisplayId(displayId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
+                               .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
     }
 
     /**
@@ -147,14 +147,14 @@ public class PostService {
         PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.by("id").descending());
 
         return postRepository.findAllByJoinFollow(getCurrentMember().getId(), lastPostId, pageRequest)
-                .stream()
-                .map(post -> PostReadResponseDto.of(post, currentMember).setCommentPreview(
-                        commentRepository.findTop3ByPostOrderByIdDesc(post)
-                                .stream()
-                                .map(comment -> CommentResponseDto.of(comment, currentMember))
-                                .collect(Collectors.toList())
-                        )
-                )
-                .collect(Collectors.toList());
+                             .stream()
+                             .map(post -> PostReadResponseDto.of(post, currentMember).setCommentPreview(
+                                     commentRepository.findTop3ByPostOrderByIdDesc(post)
+                                                      .stream()
+                                                      .map(comment -> CommentResponseDto.of(comment, currentMember))
+                                                      .collect(Collectors.toList())
+                                  )
+                             )
+                             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/util/SecurityUtil.java
+++ b/src/main/java/our/yurivongella/instagramclone/util/SecurityUtil.java
@@ -2,6 +2,7 @@ package our.yurivongella.instagramclone.util;
 
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+
 import our.yurivongella.instagramclone.exception.CustomException;
 
 import static our.yurivongella.instagramclone.exception.ErrorCode.*;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,10 +58,10 @@ spring:
       on-profile: mysql
 
   datasource:
-      url: jdbc:mysql://localhost:3306/instagram?serverTimezone=UTC&autoReconnection=true&useSSL=false
-      username: yuri
-      password: 1234
-      driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/instagram?serverTimezone=UTC&autoReconnection=true&useSSL=false
+    username: yuri
+    password: 1234
+    driver-class-name: com.mysql.cj.jdbc.Driver
 
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -41,3 +41,5 @@ INSERT INTO POST (post_id, created_date, modified_date, content, member_id, view
 INSERT INTO POST (post_id, created_date, modified_date, content, member_id, views) VALUES (100, '2021-03-15 00:01:23.278192', '2021-03-15 00:01:23.278192', 'post content', 3, 0);
 INSERT INTO POST (post_id, created_date, modified_date, content, member_id, views) VALUES (150, '2021-03-15 00:01:23.278192', '2021-03-15 00:01:23.278192', 'post content', 1, 0);
 
+
+INSERT INTO comment (created_date, modified_date, content, member_id, post_id) VALUES ('2021-03-15 00:01:23.278192','2021-03-15 00:01:23.278192','testComment',1,1);

--- a/src/test/java/our/yurivongella/instagramclone/controller/dto/MemberResponseDtoTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/controller/dto/MemberResponseDtoTest.java
@@ -32,8 +32,6 @@ class MemberResponseDtoTest {
 
         assertThat(memberResponseDto.getDisplayId()).isEqualTo(displayId);
         assertThat(memberResponseDto.getNickname()).isEqualTo(nickname);
-        assertThat(memberResponseDto.getEmail()).isEqualTo(email);
         assertThat(memberResponseDto.getProfileImageUrl()).isEqualTo(profileImageUrl);
-        assertThat(memberResponseDto.getId()).isNull();
     }
 }

--- a/src/test/java/our/yurivongella/instagramclone/service/AuthServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/AuthServiceTest.java
@@ -177,7 +177,7 @@ public class AuthServiceTest {
             assertThat(accessIsLongerThanRefresh).isTrue();
             assertThat(reissue.getAccessToken()).isInstanceOf(String.class);
             assertThat(reissue.getRefreshToken()).isInstanceOf(String.class);
-            assertThat(reissue.getGrantType()).isEqualTo("bearer");
+            assertThat(reissue.getGrantType()).isEqualTo("Bearer");
             assertThat(reissue.getAccessTokenExpiresIn()).isInstanceOf(Long.class);
         }
 

--- a/src/test/java/our/yurivongella/instagramclone/service/MemberServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/MemberServiceTest.java
@@ -97,7 +97,7 @@ class MemberServiceTest {
         @Test
         public void successFollow() {
             // when
-            memberService.follow(targetId);
+            memberService.follow(targetDisplayId);
 
             // then
             List<Follow> follows = followRepository.findByToMemberId(targetId);
@@ -121,12 +121,12 @@ class MemberServiceTest {
         @Test
         public void alreadyFollow() {
             // when
-            memberService.follow(targetId);
+            memberService.follow(targetDisplayId);
 
             // then
             Assertions.assertThrows(
                     RuntimeException.class,
-                    () -> memberService.follow(targetId)
+                    () -> memberService.follow(targetDisplayId)
             );
         }
     }
@@ -147,14 +147,14 @@ class MemberServiceTest {
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
             // 언팔로우 테스트를 위해 미리 팔로우 처리
-            memberService.follow(targetId);
+            memberService.follow(targetDisplayId);
         }
 
         @DisplayName("언팔로우 성공")
         @Test
         public void successUnFollow() {
             // when
-            memberService.unFollow(targetId);
+            memberService.unFollow(targetDisplayId);
 
             // then
             List<Follow> follows = followRepository.findByToMemberId(targetId);
@@ -165,12 +165,12 @@ class MemberServiceTest {
         @Test
         public void notFollowingTarget() {
             // when
-            memberService.unFollow(targetId);
+            memberService.unFollow(targetDisplayId);
 
             // then
             Assertions.assertThrows(
                     RuntimeException.class,
-                    () -> memberService.unFollow(targetId)
+                    () -> memberService.unFollow(targetDisplayId)
             );
         }
     }

--- a/src/test/java/our/yurivongella/instagramclone/service/PostServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/PostServiceTest.java
@@ -3,6 +3,7 @@ package our.yurivongella.instagramclone.service;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -20,7 +21,6 @@ import our.yurivongella.instagramclone.domain.post.Post;
 import our.yurivongella.instagramclone.domain.post.PostRepository;
 import our.yurivongella.instagramclone.exception.CustomException;
 import our.yurivongella.instagramclone.exception.ErrorCode;
-import our.yurivongella.instagramclone.util.SecurityUtil;
 
 import javax.persistence.EntityManager;
 import java.util.ArrayList;
@@ -193,40 +193,42 @@ public class PostServiceTest {
         assertEquals(ErrorCode.ALREADY_LIKE, customException.getErrorCode());
     }
 
-    @Transactional
-    public Long likePost() {
-        Long postId = postService.create(postCreateRequestDto);
-        postService.likePost(postId);
-        Post post = postRepository.findById(postId).get();
-        assertEquals(1L, post.getLikeCount());
-        em.flush();
-        em.clear();
-        return postId;
-    }
 
-    @DisplayName("좋아요 취소 테스트")
-    @Test
-    @Transactional
-    public void unlike_Test() {
-        Long postId = likePost();
-        ProcessStatus processStatus = postService.unlikePost(postId);
-        Post post = postRepository.findById(postId).get();
-        assertEquals(ProcessStatus.SUCCESS, processStatus);
-        assertEquals(0L, post.getLikeCount());
-    }
+    @DisplayName("취소 테스트")
+    @Nested
+    class WithdrawalClass{
+        private Long postId;
 
-    @DisplayName("좋아요 취소 중복 테스트")
-    @Test
-    @Transactional
-    public void unlike_duple_Test() {
-        Long postId = likePost();
-        ProcessStatus processStatus = postService.unlikePost(postId);
-        Post post = postRepository.findById(postId).get();
-        assertEquals(ProcessStatus.SUCCESS, processStatus);
-        assertEquals(0L, post.getLikeCount());
+        @BeforeEach
+        public void likePost() {
+            postId = postService.create(postCreateRequestDto);
+            postService.likePost(postId);
+            Post post = postRepository.findById(postId).get();
+            assertEquals(1L, post.getLikeCount());
+            em.flush();
+            em.clear();
+        }
 
-        CustomException customException = Assertions.assertThrows(CustomException.class, () -> postService.unlikePost(postId));
-        assertEquals(ErrorCode.ALREADY_UNLIKE, customException.getErrorCode());
+        @DisplayName("좋아요 취소 테스트")
+        @Test
+        public void unlike_Test() {
+            ProcessStatus processStatus = postService.unlikePost(postId);
+            Post post = postRepository.findById(postId).get();
+            assertEquals(ProcessStatus.SUCCESS, processStatus);
+            assertEquals(0L, post.getLikeCount());
+        }
+
+        @DisplayName("좋아요 취소 중복 테스트")
+        @Test
+        public void unlike_duple_Test() {
+            ProcessStatus processStatus = postService.unlikePost(postId);
+            Post post = postRepository.findById(postId).get();
+            assertEquals(ProcessStatus.SUCCESS, processStatus);
+            assertEquals(0L, post.getLikeCount());
+
+            CustomException customException = Assertions.assertThrows(CustomException.class, () -> postService.unlikePost(postId));
+            assertEquals(ErrorCode.ALREADY_UNLIKE, customException.getErrorCode());
+        }
     }
 
 }


### PR DESCRIPTION
## Description

- 포스트 좋아요 기능 추가
- 당장 쓰지는 않겠지만, 포스트에 view Count(추후 동영상) 추가 
- count를 가져올 때, 불필요한 쿼리가 나가는 것을 개선하고자, 포스트와 댓글에 count Field 추가
- OOM을 방지하고자, 쿼리로 데이터 존재 여부 체크 로직 변경
- `memberId` -> `displayId` 로 mapping 변경
- memberDto에서 email, memberId 삭제
- Bearer 변경