### PR TITLE
hotfix : cors on using put delete method

### DIFF
--- a/src/main/java/our/yurivongella/instagramclone/config/WebConfig.java
+++ b/src/main/java/our/yurivongella/instagramclone/config/WebConfig.java
@@ -1,6 +1,7 @@
 package our.yurivongella.instagramclone.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -10,6 +11,13 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
-                .allowedOrigins("*");
+                .allowedOrigins("*")
+        .allowedMethods(
+                HttpMethod.GET.name(),
+                HttpMethod.HEAD.name(),
+                HttpMethod.POST.name(),
+                HttpMethod.PUT.name(),
+                HttpMethod.DELETE.name()
+        );
     }
 }


### PR DESCRIPTION
## Description

- JWT filter까지는 도달하나, CORS에서 REST method PUT, DELETE를 받지 못하는 이슈
- WebConfig의 CorsRegistry에 default allowMethod가 head, get, post 뿐이었음 #67 

## Changes

- WebConfig에 allowMethod 설정(HEAD, GET, POST, PUT, DELETE)
 