### PR TITLE
chore: 피드 조회할 때 lastPostId 파라미터 optional 로 변경

### DIFF
--- a/src/main/java/our/yurivongella/instagramclone/controller/FeedController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/FeedController.java
@@ -23,7 +23,7 @@ public class FeedController {
 
     @ApiOperation("lastPostId 보다 작은 5 개의 인스타그램 피드 조회")
     @GetMapping("/feeds")
-    public ResponseEntity<List<PostReadResponseDto>> getFeeds(@RequestParam Long lastPostId) {
+    public ResponseEntity<List<PostReadResponseDto>> getFeeds(@RequestParam(required = false) Long lastPostId) {
         return ResponseEntity.ok(postService.getFeeds(lastPostId));
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/service/PostService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/PostService.java
@@ -125,16 +125,15 @@ public class PostService {
                                .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
     }
 
-    private Member getMemberByDisplayId(String displayId) {
-        return memberRepository.findByDisplayId(displayId)
-                               .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-    }
-
     /**
      * Instagram Feeds
      */
     @Transactional(readOnly = true)
     public List<PostReadResponseDto> getFeeds(Long lastPostId) {
+        if (lastPostId == null) {
+            lastPostId = Long.MAX_VALUE;
+        }
+
         Member currentMember = getCurrentMember();
 
         PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.by("id").descending());

--- a/src/test/java/our/yurivongella/instagramclone/service/PostServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/PostServiceTest.java
@@ -161,6 +161,23 @@ public class PostServiceTest {
         feeds.forEach(feed -> assertThat(feed.getId()).isLessThan(lastPostId));
     }
 
+    @DisplayName("특정 유저의 게시글 피드 가져오기")
+    @Test
+    public void getFeedsNoLastPostId() {
+        // given
+        Member member = memberRepository.findByEmail("woody@test.net").get();
+        Authentication authentication =
+                new UsernamePasswordAuthenticationToken(member.getId(), "", Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+        int pageSize = 5;
+
+        // when
+        List<PostReadResponseDto> feeds = postService.getFeeds(null);
+
+        // then
+        assertThat(feeds.size()).isEqualTo(pageSize);
+    }
+
     @DisplayName("좋아요 테스트")
     @Test
     @Transactional


### PR DESCRIPTION
## Description

lastPostId 값이 필수라서 첫 조회 시 값을 무조건 넣어야함

## Changes

- 프론트 요청시 값을 안넣어주면 `Long.MAX_VALUE` 값을 default 로 넣어줌
