### PR TITLE
feat: 내 정보 간단하게 조회하는 API 추가

### DIFF
--- a/src/main/java/our/yurivongella/instagramclone/controller/ProfileController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/ProfileController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import our.yurivongella.instagramclone.controller.dto.profile.ProfileDto;
 import our.yurivongella.instagramclone.controller.dto.profile.ProfilePostDto;
+import our.yurivongella.instagramclone.controller.dto.profile.SimpleProfileDto;
 import our.yurivongella.instagramclone.service.ProfileService;
 
 import java.util.List;
@@ -17,6 +18,12 @@ import java.util.List;
 @RequiredArgsConstructor
 public class ProfileController {
     private final ProfileService profileService;
+
+    @ApiOperation("내 Display Id, Profile Image Url 만 조회")
+    @GetMapping("/member")
+    public ResponseEntity<SimpleProfileDto> getMySimpleProfile() {
+        return ResponseEntity.ok(profileService.getMySimpleProfile());
+    }
 
     @ApiOperation("내 프로필 조회")
     @GetMapping("/member/profiles")

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/profile/SimpleProfileDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/profile/SimpleProfileDto.java
@@ -1,0 +1,23 @@
+package our.yurivongella.instagramclone.controller.dto.profile;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import our.yurivongella.instagramclone.domain.member.Member;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class SimpleProfileDto {
+    private String displayId;
+    private String profileImageUrl;
+
+    public static SimpleProfileDto of(Member member) {
+        return SimpleProfileDto.builder()
+                .displayId(member.getDisplayId())
+                .profileImageUrl(member.getProfileImageUrl())
+                .build();
+    }
+}

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/profile/SimpleProfileDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/profile/SimpleProfileDto.java
@@ -16,8 +16,8 @@ public class SimpleProfileDto {
 
     public static SimpleProfileDto of(Member member) {
         return SimpleProfileDto.builder()
-                .displayId(member.getDisplayId())
-                .profileImageUrl(member.getProfileImageUrl())
-                .build();
+                               .displayId(member.getDisplayId())
+                               .profileImageUrl(member.getProfileImageUrl())
+                               .build();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/service/ProfileService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/ProfileService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import our.yurivongella.instagramclone.controller.dto.profile.ProfileDto;
 import our.yurivongella.instagramclone.controller.dto.profile.ProfilePostDto;
+import our.yurivongella.instagramclone.controller.dto.profile.SimpleProfileDto;
 import our.yurivongella.instagramclone.domain.follow.FollowRepository;
 import our.yurivongella.instagramclone.domain.member.Member;
 import our.yurivongella.instagramclone.domain.member.MemberRepository;
@@ -33,6 +34,10 @@ public class ProfileService {
     private final FollowRepository followRepository;
     private final PostRepository postRepository;
     private final PostLikeRepository postLikeRepository;
+
+    public SimpleProfileDto getMySimpleProfile() {
+        return SimpleProfileDto.of(getCurrentMember());
+    }
 
     public ProfileDto getMyProfile() {
         return ProfileDto.of(getCurrentMember());

--- a/src/test/java/our/yurivongella/instagramclone/service/ProfileServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/ProfileServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 import our.yurivongella.instagramclone.controller.dto.profile.ProfileDto;
 import our.yurivongella.instagramclone.controller.dto.profile.ProfileMemberDto;
 import our.yurivongella.instagramclone.controller.dto.profile.ProfilePostDto;
+import our.yurivongella.instagramclone.controller.dto.profile.SimpleProfileDto;
 import our.yurivongella.instagramclone.domain.member.Member;
 import our.yurivongella.instagramclone.domain.member.MemberRepository;
 import our.yurivongella.instagramclone.util.SecurityUtil;
@@ -42,6 +43,17 @@ class ProfileServiceTest {
                 new UsernamePasswordAuthenticationToken(myMemberId, "", Collections.emptyList());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
+
+    @DisplayName("내 정보 간단하게 조회")
+    @Test
+    void getMySimpleProfileTest() {
+        SimpleProfileDto myProfile = profileService.getMySimpleProfile();
+        Member member = memberRepository.findById(SecurityUtil.getCurrentMemberId()).get();
+
+        assertThat(myProfile.getDisplayId()).isEqualTo(member.getDisplayId());
+        assertThat(myProfile.getProfileImageUrl()).isNull();
+    }
+
 
     @DisplayName("내 정보 조회")
     @Test


### PR DESCRIPTION
## Description

인스타 메인 피드 화면에서 내 ProfileImageUrl 을 간단하게 노출해야 합니다.

`GET /member/profiles` 에서 내려주는 정보는 불필요하게 많다고 생각해서 간단하게 `displayId, profileImageUrl` 을 내려주는 API 를 하나 추가합니다.

## Changes

- `GET /member` API 추가
- 테스트 코드 작성
