### PR TITLE
CommentDto 에서 사용하는 MemberDto -> MemberResDto 로 변경

### DIFF
--- a/src/main/java/our/yurivongella/instagramclone/controller/CommentController.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/CommentController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import our.yurivongella.instagramclone.controller.dto.ProcessStatus;
+import our.yurivongella.instagramclone.controller.dto.comment.CommentDto;
 import our.yurivongella.instagramclone.controller.dto.comment.CommentReqDto;
 
 import io.swagger.annotations.ApiOperation;
@@ -30,46 +31,46 @@ public class CommentController {
 
     @ApiOperation("게시글의 댓글 리스트 조회")
     @GetMapping("/posts/{postId}/comments")
-    public CommentResDto getComments(@PathVariable("postId") Long postId, @RequestParam(value = "lastId", required = false) Long lastId) {
-        return commentService.getCommentsFromPost(postId, lastId);
+    public ResponseEntity<CommentResDto> getComments(@PathVariable("postId") Long postId, @RequestParam(value = "lastId", required = false) Long lastId) {
+        return ResponseEntity.ok(commentService.getCommentsFromPost(postId, lastId));
     }
 
     @ApiOperation("게시글에 새로운 댓글 생성")
     @PostMapping("/posts/{postId}/comments")
-    public ResponseEntity createComment(@PathVariable("postId") Long postId, @RequestBody @Valid CommentReqDto commentReqDto) {
+    public ResponseEntity<CommentDto> createComment(@PathVariable("postId") Long postId, @RequestBody @Valid CommentReqDto commentReqDto) {
         return ResponseEntity.ok(commentService.createComment(postId, commentReqDto));
     }
 
     @ApiOperation("해당 댓글 삭제")
     @DeleteMapping("/comments/{commentId}")
-    public ResponseEntity deleteComment(@PathVariable("commentId") Long commentId) {
+    public ResponseEntity<String> deleteComment(@PathVariable("commentId") Long commentId) {
         ProcessStatus processStatus = commentService.deleteComment(commentId);
         return ResponseEntity.ok(processStatus.getMessage());
     }
 
     @ApiOperation("댓글에 좋아요")
     @PutMapping("/comments/{commentId}/like")
-    public ResponseEntity likeComment(@PathVariable("commentId") Long commentId) throws Exception {
+    public ResponseEntity<String> likeComment(@PathVariable("commentId") Long commentId) throws Exception {
         ProcessStatus processStatus = commentService.likeComment(commentId);
         return ResponseEntity.ok(processStatus.getMessage());
     }
 
     @ApiOperation("댓글 좋아요 취소")
     @DeleteMapping("/comments/{commentId}/like")
-    public ResponseEntity unlikeComment(@PathVariable("commentId") Long commentId) throws Exception {
+    public ResponseEntity<String> unlikeComment(@PathVariable("commentId") Long commentId) throws Exception {
         ProcessStatus processStatus = commentService.unlikeComment(commentId);
         return ResponseEntity.ok(processStatus.getMessage());
     }
 
     @ApiOperation("대댓글 정보 가져오기")
     @GetMapping("/comments/{commentId}/nested-comments")
-    public ResponseEntity getNestedComments(@PathVariable("commentId") Long commentId, @RequestParam(value = "lastId", required = false) Long lastId) {
+    public ResponseEntity<CommentResDto> getNestedComments(@PathVariable("commentId") Long commentId, @RequestParam(value = "lastId", required = false) Long lastId) {
         return ResponseEntity.ok(commentService.findNestedComments(commentId, lastId));
     }
 
     @ApiOperation("대댓글 달기")
     @PostMapping("/comments/{commentId}/nested-comments")
-    public ResponseEntity createNestedComment(@PathVariable("commentId") Long commentId, @RequestBody @Valid CommentReqDto commentReqDto) {
+    public ResponseEntity<CommentDto> createNestedComment(@PathVariable("commentId") Long commentId, @RequestBody @Valid CommentReqDto commentReqDto) {
         return ResponseEntity.ok(commentService.createNestedComment(commentId, commentReqDto));
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentDto.java
@@ -21,15 +21,15 @@ public class CommentDto {
     private LocalDateTime createdDate;
 
     public static CommentDto of(Comment comment) {
-        return CommentDto.builder()
-                         .id(comment.getId())
-                         .content(comment.getContent())
-                         .author(MemberResDto.of(comment.getMember()))
-                         .isLike(false)
-                         .likeCount(comment.getLikeCount())
-                         .nestedCommentCount(comment.getNestedComments().size())
-                         .createdDate(comment.getCreatedDate())
-                         .build();
+        return builder()
+              .id(comment.getId())
+              .content(comment.getContent())
+              .author(MemberResDto.of(comment.getMember()))
+              .isLike(false)
+              .likeCount(comment.getLikeCount())
+              .nestedCommentCount(comment.getNestedComments().size())
+              .createdDate(comment.getCreatedDate())
+              .build();
     }
 
     public void setLikeTrue() {

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentDto.java
@@ -1,60 +1,38 @@
 package our.yurivongella.instagramclone.controller.dto.comment;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-import lombok.ToString;
-import our.yurivongella.instagramclone.controller.dto.member.MemberDto;
-import our.yurivongella.instagramclone.entity.Member;
-
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-
+import lombok.*;
+import our.yurivongella.instagramclone.controller.dto.member.MemberResDto;
 import our.yurivongella.instagramclone.entity.Comment;
 
 import java.time.LocalDateTime;
 
 @ToString
 @Getter
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
 public class CommentDto {
-
     private Long id;
-
     private String content;
-
-    private MemberDto author;
-
+    private MemberResDto author;
     private Boolean isLike;
-
-    @JsonProperty("likeLength")
     private Long likeCount;
+    private Integer nestedCommentCount;
+    private LocalDateTime createdDate;
 
-    private Integer replyLength;
-
-    private LocalDateTime created;
-
-    @Builder
-    public CommentDto(final Long id, final String content, final MemberDto author, final Boolean isLike, final Long likeCount, final Integer replyLength,
-                      final LocalDateTime created) {
-        this.id = id;
-        this.content = content;
-        this.author = author;
-        this.isLike = isLike;
-        this.likeCount = likeCount;
-        this.replyLength = replyLength;
-        this.created = created;
+    public static CommentDto of(Comment comment) {
+        return CommentDto.builder()
+                         .id(comment.getId())
+                         .content(comment.getContent())
+                         .author(MemberResDto.of(comment.getMember()))
+                         .isLike(false)
+                         .likeCount(comment.getLikeCount())
+                         .nestedCommentCount(comment.getNestedComments().size())
+                         .createdDate(comment.getCreatedDate())
+                         .build();
     }
 
-    public static CommentDto of(Comment comment, Member member) {
-        return builder()
-                .id(comment.getId())
-                .content(comment.getContent())
-                .author(MemberDto.of(comment.getMember(), member))
-                .isLike(comment.getCommentLikes().stream().anyMatch(v -> v.getMember().getId().equals(member.getId())))
-                .likeCount(comment.getLikeCount())
-                .replyLength(comment.getNestedComments().size())
-                .created(comment.getCreatedDate())
-                .build();
+    public void setLikeTrue() {
+        this.isLike = true;
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentResDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentResDto.java
@@ -15,9 +15,9 @@ public class CommentResDto {
     private List<CommentDto> comments = new ArrayList<>();
 
     public static CommentResDto of(boolean hasNext, List<CommentDto> comments) {
-        return CommentResDto.builder()
-                            .hasNext(hasNext)
-                            .comments(comments)
-                            .build();
+        return builder()
+              .hasNext(hasNext)
+              .comments(comments)
+              .build();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentResDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentResDto.java
@@ -12,12 +12,12 @@ import lombok.*;
 @ToString
 public class CommentResDto {
     private Boolean hasNext;
-    private List<CommentDto> commentResDtos = new ArrayList<>();
+    private List<CommentDto> comments = new ArrayList<>();
 
-    public static CommentResDto of(boolean hasNext, List<CommentDto> commentResDto) {
+    public static CommentResDto of(boolean hasNext, List<CommentDto> comments) {
         return CommentResDto.builder()
                             .hasNext(hasNext)
-                            .commentResDtos(commentResDto)
+                            .comments(comments)
                             .build();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentResDto.java
+++ b/src/main/java/our/yurivongella/instagramclone/controller/dto/comment/CommentResDto.java
@@ -1,21 +1,12 @@
 package our.yurivongella.instagramclone.controller.dto.comment;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.ArrayList;
 import java.util.List;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.ToString;
-import our.yurivongella.instagramclone.util.SliceHelper;
-import our.yurivongella.instagramclone.entity.Comment;
-import our.yurivongella.instagramclone.entity.Member;
+import lombok.*;
 
 @Getter
-@Setter
+@Builder
 @NoArgsConstructor
 @AllArgsConstructor
 @ToString
@@ -23,14 +14,10 @@ public class CommentResDto {
     private Boolean hasNext;
     private List<CommentDto> commentResDtos = new ArrayList<>();
 
-    public static CommentResDto create(final Member member, final List<Comment> content, final int COMMENT_PAGE_SIZE) {
-        CommentResDto commentResDto = new CommentResDto();
-        final boolean hasNext = SliceHelper.hasNext(content, COMMENT_PAGE_SIZE);
-        commentResDto.setCommentResDtos(SliceHelper.getContents(content, hasNext, COMMENT_PAGE_SIZE)
-                                                   .stream()
-                                                   .map(comment -> CommentDto.of(comment, member))
-                                                   .collect(toList()));
-        commentResDto.setHasNext(hasNext);
-        return commentResDto;
+    public static CommentResDto of(boolean hasNext, List<CommentDto> commentResDto) {
+        return CommentResDto.builder()
+                            .hasNext(hasNext)
+                            .commentResDtos(commentResDto)
+                            .build();
     }
 }

--- a/src/main/java/our/yurivongella/instagramclone/repository/CommentLikeRepository.java
+++ b/src/main/java/our/yurivongella/instagramclone/repository/CommentLikeRepository.java
@@ -3,9 +3,11 @@ package our.yurivongella.instagramclone.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import our.yurivongella.instagramclone.entity.Comment;
 import our.yurivongella.instagramclone.entity.CommentLike;
+import our.yurivongella.instagramclone.entity.Member;
 
 public interface CommentLikeRepository extends JpaRepository<CommentLike, Long> {
 
-    Optional<CommentLike> findByCommentIdAndMemberId(Long commentId, Long memberId);
+    Optional<CommentLike> findByMemberAndComment(Member member, Comment comment);
 }

--- a/src/main/java/our/yurivongella/instagramclone/service/CommentService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/CommentService.java
@@ -96,7 +96,7 @@ public class CommentService {
     }
 
     private CommentLike createCommentLike(Member member, Comment comment) {
-        commentLikeRepository.findByCommentIdAndMemberId(comment.getId(), member.getId()).ifPresent(commentLike -> {
+        commentLikeRepository.findByMemberAndComment(member, comment).ifPresent(commentLike -> {
             log.error("[댓글 번호:{}] {}가 이미 좋아요를 하고 있습니다.", comment.getId(), member.getId());
             throw new CustomException(ALREADY_LIKE);
         });
@@ -107,7 +107,7 @@ public class CommentService {
     public ProcessStatus unlikeComment(@NotNull Long commentId) {
         Member member = getCurrentMember();
         Comment comment = getCurrentComment(commentId);
-        CommentLike commentLike = commentLikeRepository.findByCommentIdAndMemberId(commentId, member.getId()).orElseThrow(() -> new CustomException(ALREADY_UNLIKE));
+        CommentLike commentLike = commentLikeRepository.findByMemberAndComment(member, comment).orElseThrow(() -> new CustomException(ALREADY_UNLIKE));
 
         try {
             commentLike.unlike();
@@ -152,7 +152,7 @@ public class CommentService {
         followRepository.findByFromMemberAndToMember(currentMember, comment.getMember())
                         .ifPresent(ignored -> commentDto.getAuthor().setFollowTrue());
 
-        commentLikeRepository.findByCommentIdAndMemberId(comment.getId(), currentMember.getId())
+        commentLikeRepository.findByMemberAndComment(currentMember, comment)
                              .ifPresent(ignored -> commentDto.setLikeTrue());
 
         return commentDto;

--- a/src/main/java/our/yurivongella/instagramclone/service/PostService.java
+++ b/src/main/java/our/yurivongella/instagramclone/service/PostService.java
@@ -126,7 +126,7 @@ public class PostService {
 
     private Member getCurrentMember() {
         return memberRepository.findById(SecurityUtil.getCurrentMemberId())
-                               .orElseThrow(() -> new NoSuchElementException("현재 계정 정보가 존재하지 않습니다."));
+                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED_MEMBER));
     }
 
     @Transactional(readOnly = true)
@@ -141,7 +141,7 @@ public class PostService {
         PostResDto postResDto = new PostResDto();
         final boolean hasNext = SliceHelper.hasNext(content, pageSize);
         postResDto.setHasNext(hasNext);
-        content = SliceHelper.getContents(content, hasNext, pageSize);
+        content = SliceHelper.getContents(content, pageSize);
 
         postResDto.setFeeds(content.stream()
                                    .map(post -> PostReadResDto.of(post, currentMember))

--- a/src/main/java/our/yurivongella/instagramclone/util/SliceHelper.java
+++ b/src/main/java/our/yurivongella/instagramclone/util/SliceHelper.java
@@ -21,8 +21,8 @@ public class SliceHelper {
         return content.size() > pageSize;
     }
 
-    public static <T> List<T> getContents(final List<T> content, final boolean hasNext, final int pageSize) {
-        if (hasNext) {
+    public static <T> List<T> getContents(final List<T> content, final int pageSize) {
+        if (hasNext(content, pageSize)) {
             content.remove(pageSize);
         }
         return content;

--- a/src/test/java/our/yurivongella/instagramclone/controller/dto/comment/CommentDtoTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/controller/dto/comment/CommentDtoTest.java
@@ -1,0 +1,52 @@
+package our.yurivongella.instagramclone.controller.dto.comment;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import our.yurivongella.instagramclone.entity.Comment;
+import our.yurivongella.instagramclone.entity.Member;
+import our.yurivongella.instagramclone.entity.Post;
+
+import static org.assertj.core.api.Assertions.*;
+
+public class CommentDtoTest {
+
+    @DisplayName("Comment -> CommentDto 테스트")
+    @Test
+    void test() {
+        // given
+        Member member = createMember();
+        Post post = createPost();
+        Comment comment = new Comment(member, post, "test content");
+
+        // when
+        CommentDto commentDto = CommentDto.of(comment);
+
+        // then
+        assertThat(commentDto.getId()).isEqualTo(comment.getId());
+        assertThat(commentDto.getContent()).isEqualTo("test content");
+        assertThat(commentDto.getAuthor().getDisplayId()).isEqualTo("test");
+        assertThat(commentDto.getIsLike()).isFalse();
+        assertThat(commentDto.getLikeCount()).isEqualTo(0L);
+        assertThat(commentDto.getNestedCommentCount()).isEqualTo(0);
+
+        commentDto.setLikeTrue();
+        assertThat(commentDto.getIsLike()).isTrue();
+    }
+
+    private Member createMember() {
+        return Member.builder()
+                     .displayId("test")
+                     .nickname("test nickname")
+                     .email("test@test.net")
+                     .password("1q2w3e4r")
+                     .profileImageUrl("test.img")
+                     .build();
+    }
+
+    private Post createPost() {
+        return Post.builder()
+                   .content("test post")
+                   .build();
+    }
+}

--- a/src/test/java/our/yurivongella/instagramclone/controller/dto/member/MemberDtoTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/controller/dto/member/MemberDtoTest.java
@@ -1,4 +1,4 @@
-package our.yurivongella.instagramclone.controller.dto;
+package our.yurivongella.instagramclone.controller.dto.member;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/our/yurivongella/instagramclone/controller/dto/member/MemberResDtoTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/controller/dto/member/MemberResDtoTest.java
@@ -1,4 +1,4 @@
-package our.yurivongella.instagramclone.controller.dto;
+package our.yurivongella.instagramclone.controller.dto.member;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/our/yurivongella/instagramclone/domain/post/PostRepositoryTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/domain/post/PostRepositoryTest.java
@@ -1,8 +1,0 @@
-package our.yurivongella.instagramclone.domain.post;
-
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-
-@DataJpaTest
-class PostRepositoryTest {
-
-}

--- a/src/test/java/our/yurivongella/instagramclone/service/CommentServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/CommentServiceTest.java
@@ -50,7 +50,7 @@ class CommentServiceTest extends TestBase {
         CommentResDto dto =  commentService.getCommentsFromPost(postId, null);
 
         assertThat(dto.getHasNext()).isFalse();
-        assertThat(dto.getCommentResDtos()).isEmpty();
+        assertThat(dto.getComments()).isEmpty();
     }
 
     @DisplayName("댓글 추가 테스트")
@@ -69,7 +69,7 @@ class CommentServiceTest extends TestBase {
 
             // then
             CommentResDto commentResDto = commentService.getCommentsFromPost(postId, null);
-            List<CommentDto> commentDtos = commentResDto.getCommentResDtos();
+            List<CommentDto> commentDtos = commentResDto.getComments();
 
             assertThat(commentDtos.size()).isEqualTo(2);
 

--- a/src/test/java/our/yurivongella/instagramclone/service/CommentServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/CommentServiceTest.java
@@ -1,7 +1,7 @@
 package our.yurivongella.instagramclone.service;
 
 import java.util.Collections;
-import java.util.Optional;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,289 +9,299 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.transaction.annotation.Transactional;
 
 import our.yurivongella.instagramclone.controller.dto.comment.CommentReqDto;
 import our.yurivongella.instagramclone.controller.dto.comment.CommentResDto;
-import our.yurivongella.instagramclone.controller.dto.member.SignupReqDto;
 import our.yurivongella.instagramclone.controller.dto.ProcessStatus;
 import our.yurivongella.instagramclone.controller.dto.comment.CommentDto;
+import our.yurivongella.instagramclone.controller.dto.post.PostCreateReqDto;
 import our.yurivongella.instagramclone.entity.Comment;
 import our.yurivongella.instagramclone.repository.comment.CommentRepository;
-import our.yurivongella.instagramclone.entity.Member;
-import our.yurivongella.instagramclone.repository.MemberRepository;
-import our.yurivongella.instagramclone.entity.Post;
-import our.yurivongella.instagramclone.repository.post.PostRepository;
 import our.yurivongella.instagramclone.exception.CustomException;
 import our.yurivongella.instagramclone.exception.ErrorCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
-@Transactional
-@SpringBootTest
-class CommentServiceTest {
-    @MockBean
-    private S3Service s3Service;
+@DisplayName("댓글 Service 테스트")
+class CommentServiceTest extends TestBase {
 
     @Autowired
     private CommentService commentService;
 
     @Autowired
-    private PostRepository postRepository;
-
-    @Autowired
     private CommentRepository commentRepository;
 
     @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private AuthService authService;
-
-    private Long userId;
-    private Long postId;
-    private Long commentId;
-
-    String displayId = "testName";
-    String nickname = "testNick";
-    String email = "test@naver.com";
-    String password = "testPassword";
+    private PostService postService;
 
     @BeforeEach
-    public void prepare_member_and_post() {
-        SignupReqDto signupReqDto = SignupReqDto.builder()
-                                                .displayId(displayId)
-                                                .nickname(nickname)
-                                                .email(email)
-                                                .password(password)
-                                                .build();
-
-        // 가입
-        authService.signup(signupReqDto);
-        userId = memberRepository.findByEmail(email).get().getId();
-
-        Authentication authentication =
-                new UsernamePasswordAuthenticationToken(userId, "", Collections.emptyList());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        Post post = Post.builder()
-                        .content("test")
-                        .build();
-        Member member = memberRepository.findById(userId).get();
-        post.addMember(member);
-        Post save = postRepository.save(post);
-        postId = save.getId();
-        assertNotNull(save);
+    void loginBeforeTest() {
+        signupAndLogin("testComment", "testComment@test.net");
     }
 
+    @DisplayName("댓글 없을 때 가져오면 비어있는 응답 제공")
+    @Test
+    void testGetCommentsFromPost() {
+        // given
+        Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+
+        // then
+        CommentResDto dto =  commentService.getCommentsFromPost(postId, null);
+
+        assertThat(dto.getHasNext()).isFalse();
+        assertThat(dto.getCommentResDtos()).isEmpty();
+    }
+
+    @DisplayName("댓글 추가 테스트")
     @Nested
-    @DisplayName("댓글이 존재하지 않을 때의 테스트")
-    class CommentTest1 {
+    class createCommentTest {
 
-        private Long notExistCommendId = 123456L;
-
+        @DisplayName("댓글 2 개 추가 성공")
         @Test
-        @DisplayName("댓글 달기")
-        void create_comment() {
-            CommentReqDto commentReqDto = new CommentReqDto("test");
-            CommentDto comment = commentService.createComment(postId, commentReqDto);
+        void success() {
+            // given
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
 
-            assertEquals("test", comment.getContent());
-            assertEquals("testName", comment.getAuthor().getDisplayId());
-            assertEquals(0, comment.getLikeCount());
-            assertFalse(comment.getIsLike());
+            // when
+            commentService.createComment(postId, new CommentReqDto("test comment"));
+            commentService.createComment(postId, new CommentReqDto("test comment2"));
 
-            Comment savedComment = commentRepository.findById(comment.getId()).get();
-            assertEquals(1, savedComment.getPost().getCommentCount());
+            // then
+            CommentResDto commentResDto = commentService.getCommentsFromPost(postId, null);
+            List<CommentDto> commentDtos = commentResDto.getCommentResDtos();
+
+            assertThat(commentDtos.size()).isEqualTo(2);
+
+            CommentDto commentDto1 = commentDtos.get(0);
+            assertThat(commentDto1.getContent()).isEqualTo("test comment2");
+            assertThat(commentDto1.getLikeCount()).isEqualTo(0);
+            assertThat(commentDto1.getNestedCommentCount()).isEqualTo(0);
+            assertThat(commentDto1.getAuthor().getDisplayId()).isEqualTo("testComment");
+
+            CommentDto commentDto2 = commentDtos.get(1);
+            assertThat(commentDto2.getContent()).isEqualTo("test comment");
+            assertThat(commentDto2.getLikeCount()).isEqualTo(0);
+            assertThat(commentDto2.getNestedCommentCount()).isEqualTo(0);
+            assertThat(commentDto2.getAuthor().getDisplayId()).isEqualTo("testComment");
         }
 
-        @DisplayName("존재하지 않는 댓글 삭제")
+        @DisplayName("게시글이 없는 경우 댓글 달기 실패")
         @Test
-        void delete_comment1() {
-            CustomException customException = assertThrows(CustomException.class, () -> commentService.deleteComment(notExistCommendId));
-            Assertions.assertEquals(ErrorCode.COMMENT_NOT_FOUND, customException.getErrorCode());
+        void failWhenNonExistentPost() {
+            CommentReqDto commentReqDto = new CommentReqDto("test comment");
+
+            CustomException ex = assertThrows(CustomException.class, () -> commentService.createComment(-1L, commentReqDto));
+
+            Assertions.assertEquals(ErrorCode.POST_NOT_FOUND, ex.getErrorCode());
+        }
+    }
+
+    @DisplayName("댓글 삭제 테스트")
+    @Nested
+    class deleteCommentTest {
+
+        @DisplayName("댓글 삭제 성공")
+        @Test
+        void successDelete() {
+            // given
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+            CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
+            Comment deletedComment = commentRepository.findById(commentDto.getId()).get();
+
+            // when
+            ProcessStatus processStatus = commentService.deleteComment(commentDto.getId());
+
+            // then
+            assertThat(processStatus).isEqualTo(ProcessStatus.SUCCESS);
+            assertThat(commentRepository.findById(commentDto.getId())).isEmpty();
+            assertThat(deletedComment.getPost().getCommentCount()).isEqualTo(0);
         }
 
+        @DisplayName("없는 댓글 지우려 하면 실패")
         @Test
-        @DisplayName("댓글 불러오기")
-        void getComment_test() {
-            CommentResDto commentResDto =  commentService.getCommentsFromPost(postId, null);
-            assertEquals(0, commentResDto.getCommentResDtos().size());
+        void failWhenDeleteNonExistentComment() {
+            CustomException ex = assertThrows(CustomException.class, () -> commentService.deleteComment(-1L));
+            Assertions.assertEquals(ErrorCode.COMMENT_NOT_FOUND, ex.getErrorCode());
         }
 
-        @DisplayName("존재하지 않는 댓글 좋아요")
+        @DisplayName("다른 사람의 댓글 지우려 하면 실패")
+        @Test
+        void failWhenDeleteNotMineComment() {
+            // testComment 계정으로 댓글 작성 후 other 계정으로 댓글 삭제 시도
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+            CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
+            Comment deletedComment = commentRepository.findById(commentDto.getId()).get();
+
+            // when
+            signupAndLogin("other", "other@test.net");
+            ProcessStatus processStatus = commentService.deleteComment(commentDto.getId());
+
+            // then
+            assertThat(processStatus).isEqualTo(ProcessStatus.FAIL);
+            assertThat(commentRepository.findById(commentDto.getId())).isPresent();
+            assertThat(deletedComment.getPost().getCommentCount()).isEqualTo(1);
+        }
+    }
+
+    @DisplayName("좋아요 테스트")
+    @Nested
+    class likeCommentTest {
+
+        @DisplayName("좋아요 성공")
+        @Test
+        void successLike() {
+            // given
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+            CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
+
+            // when
+            ProcessStatus processStatus = commentService.likeComment(commentDto.getId());
+
+            // then
+            assertThat(processStatus).isEqualTo(ProcessStatus.SUCCESS);
+            Comment comment = commentRepository.findById(commentDto.getId()).get();
+            assertThat(comment.getLikeCount()).isEqualTo(1);
+        }
+
+        @DisplayName("없는 댓글에 좋아요 하려고 하면 실패")
+        @Test
+        void failWhenNonExistentComment() {
+            CustomException ex = assertThrows(CustomException.class, () -> commentService.likeComment(-1L));
+            assertEquals(ErrorCode.COMMENT_NOT_FOUND, ex.getErrorCode());
+        }
+
+        @DisplayName("이미 좋아요 되어 있으면 실패")
+        @Test
+        void failWhenAlreadyLiked() {
+            // given
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+            CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
+
+            // when
+            commentService.likeComment(commentDto.getId());
+
+            // then
+            CustomException ex = assertThrows(CustomException.class, () -> commentService.likeComment(commentDto.getId()));
+            assertEquals(ErrorCode.ALREADY_LIKE, ex.getErrorCode());
+        }
+    }
+
+    @DisplayName("좋아요 취소 테스트")
+    @Nested
+    class unlikeCommentTest {
+
+        @DisplayName("좋아요 취소 성공")
+        @Test
+        void successUnlike() {
+            // given
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+            CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
+
+            // when
+            commentService.likeComment(commentDto.getId());
+            ProcessStatus processStatus = commentService.unlikeComment(commentDto.getId());
+
+            // then
+            assertThat(processStatus).isEqualTo(ProcessStatus.SUCCESS);
+            Comment comment = commentRepository.findById(commentDto.getId()).get();
+            assertThat(comment.getLikeCount()).isEqualTo(0);
+        }
+
+        @DisplayName("없는 댓글에 좋아요 취소 하려고 하면 실패")
+        @Test
+        void failWhenNonExistentComment() {
+            CustomException ex = assertThrows(CustomException.class, () -> commentService.unlikeComment(-1L));
+            assertEquals(ErrorCode.COMMENT_NOT_FOUND, ex.getErrorCode());
+        }
+
+        @DisplayName("좋아요 되어있지 않으면 실패")
+        @Test
+        void failWhenAlreadyUnlike() {
+            // given
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+            CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
+
+            // when
+            CustomException ex = assertThrows(CustomException.class, () -> commentService.unlikeComment(commentDto.getId()));
+
+            // then
+            assertEquals(ErrorCode.ALREADY_UNLIKE, ex.getErrorCode());
+        }
+    }
+
+    @DisplayName("null 체크")
+    @Nested
+    class NullCommentIdTest {
+
+        @BeforeEach
+        void beforeEach() {
+            postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+        }
+
+        @DisplayName("commentId = null 로 들어오는 comment 삭제 실패")
+        @Test
+        void deleteComment() {
+            Exception exception = assertThrows(Exception.class, () -> commentService.deleteComment(null));
+            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+            assertEquals("The given id must not be null!", exception.getCause().getMessage());
+        }
+
+        @DisplayName("commentId = null 로 들어오는 comment 좋아요 실패")
         @Test
         void like() {
-            CustomException customException = assertThrows(CustomException.class, () -> commentService.likeComment(notExistCommendId));
-            assertEquals(ErrorCode.COMMENT_NOT_FOUND, customException.getErrorCode());
+            Exception exception = assertThrows(Exception.class, () -> commentService.likeComment(null));
+            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+            assertEquals("The given id must not be null!", exception.getCause().getMessage());
         }
 
-        @DisplayName("존재하지 않는 댓글 좋아요 취소")
+        @DisplayName("commentId = null 로 들어오는 comment 좋아요 취소 실패")
         @Test
         void unlike() {
-            CustomException customException = assertThrows(CustomException.class, () -> commentService.unlikeComment(notExistCommendId));
-            assertEquals(ErrorCode.COMMENT_NOT_FOUND, customException.getErrorCode());
-
+            Exception exception = assertThrows(Exception.class, () -> commentService.unlikeComment(null));
+            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
+            assertEquals("The given id must not be null!", exception.getCause().getMessage());
         }
     }
 
+    @DisplayName("대댓글 테스트")
     @Nested
-    @DisplayName("댓글이 존재할 때의 테스트")
-    class CommentIs {
-        @BeforeEach
-        public void prepare_data() {// 댓글 불러오기, 삭제/좋아요 취소 테스트를 위해 댓글 1건을 미리 준비합니다.
-            CommentReqDto commentReqDto = new CommentReqDto("test");
-            Post post = postRepository.findById(postId).get();
-            CommentDto comment = commentService.createComment(postId, commentReqDto);
-            commentId = post.getComments().get(0).getId();
-            assertNotNull(comment);
-        }
+    class NestedCommentTest {
 
-        @DisplayName("본인이 본인 댓글 삭제")
+        @DisplayName("대댓글 생성 및 조회 성공")
         @Test
-        void delete_comment1() {
-            Comment deletedComment = commentRepository.findById(commentId).get();
-            assertEquals(1, deletedComment.getPost().getCommentCount());
+        void successCreateAndRead() {
+            // given
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+            CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
 
-            ProcessStatus processStatus = commentService.deleteComment(commentId);
-            Optional<Comment> comment = commentRepository.findById(commentId);
-            assertEquals(Optional.empty(), comment);
-            assertEquals(ProcessStatus.SUCCESS, processStatus);
-            assertEquals(0, deletedComment.getPost().getCommentCount());
+            // when
+            commentService.createNestedComment(commentDto.getId(), new CommentReqDto("대댓글"));
+            commentService.createNestedComment(commentDto.getId(), new CommentReqDto("대댓글2"));
+
+            // then
+            Comment baseComment = commentRepository.findById(commentDto.getId()).get();
+
+            assertThat(baseComment.getBaseComment()).isNull(); // 최상위 댓글
+            assertThat(baseComment.getContent()).isEqualTo("test comment");
+            assertThat(baseComment.getNestedComments().size()).isEqualTo(2);
+            assertThat(baseComment.getNestedComments()).extracting("content").containsExactly("대댓글", "대댓글2");
         }
 
-        @DisplayName("타인이 타인 댓글 삭제")
+        @DisplayName("존재하지 않는 대댓글 조회 성공")
         @Test
-        void delete_comment2() {
-            String displayId = "other";
-            String nickname = "other";
-            String email = "other@naver.com";
-            String password = "other";
-            SignupReqDto signupReqDto = SignupReqDto.builder()
-                                                    .displayId(displayId)
-                                                    .nickname(nickname)
-                                                    .email(email)
-                                                    .password(password)
-                                                    .build();
+        void failWhenNonExistentNestedComment() {
+            // given
+            Long postId = postService.create(new PostCreateReqDto(Collections.emptyList(), "test post"));
+            CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
 
-            // 가입
-            authService.signup(signupReqDto);
-            Long otherId = memberRepository.findByEmail(email).get().getId();
+            // when
+            Comment baseComment = commentRepository.findById(commentDto.getId()).get();
 
-            Authentication authentication = new UsernamePasswordAuthenticationToken(otherId, "", Collections.emptyList());
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-            assertEquals(ProcessStatus.FAIL, commentService.deleteComment(commentId));
-            Optional<Comment> comment = commentRepository.findById(commentId);
-            assertTrue(comment.isPresent());
+            // then
+            assertThat(baseComment.getBaseComment()).isNull(); // 최상위 댓글
+            assertThat(baseComment.getContent()).isEqualTo("test comment");
+            assertThat(baseComment.getNestedComments().size()).isEqualTo(0);
         }
-
-        @Test
-        @DisplayName("댓글 불러오기")
-        public void getComment_test() {
-            CommentResDto dto = commentService.getCommentsFromPost(postId, null);
-            assertEquals("test", dto.getCommentResDtos().get(0).getContent());
-            assertEquals(1, dto.getCommentResDtos().size());
-        }
-
-        @DisplayName("댓글 좋아요")
-        @Test
-        public void like() throws Exception {
-            ProcessStatus processStatus = commentService.likeComment(commentId);
-            Comment comment = commentRepository.findById(commentId).orElseThrow();
-            assertEquals(ProcessStatus.SUCCESS, processStatus);
-            assertEquals(1, comment.getCommentLikes().size());
-
-            CustomException customException = assertThrows(CustomException.class, () -> commentService.likeComment(commentId));
-            assertEquals(ErrorCode.ALREADY_LIKE, customException.getErrorCode()); // 중복 처리
-        }
-
-        @DisplayName("댓글 좋아요 취소")
-        @Test
-        public void unlike() throws Exception {
-            ProcessStatus processStatus = commentService.likeComment(commentId);
-            Comment comment = commentRepository.findById(commentId).orElseThrow();
-            assertEquals(ProcessStatus.SUCCESS, processStatus);
-            assertEquals(1, comment.getCommentLikes().size());
-
-            processStatus = commentService.unlikeComment(commentId);
-            comment = commentRepository.findById(commentId).orElseThrow();
-            assertEquals(ProcessStatus.SUCCESS, processStatus);
-            assertEquals(0, comment.getCommentLikes().size());
-
-            CustomException customException = assertThrows(CustomException.class, () -> commentService.unlikeComment(commentId));
-            assertEquals(ErrorCode.ALREADY_UNLIKE, customException.getErrorCode()); // 중복 처리
-        }
-    }
-
-    @Nested
-    @DisplayName("null 체크")
-    class nullComment_test {
-        @DisplayName("commentId = null로 들어오는 comment 삭제")
-        @Test
-        public void delete_comment1() {
-            Exception exception = assertThrows(Exception.class, () -> commentService.deleteComment(commentId));
-            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
-            assertEquals("The given id must not be null!", exception.getCause().getMessage());
-        }
-
-        @DisplayName("commentId = null로 들어오는 comment 좋아요")
-        @Test
-        public void like() {
-            Exception exception = assertThrows(Exception.class, () -> commentService.likeComment(commentId));
-            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
-            assertEquals("The given id must not be null!", exception.getCause().getMessage());
-        }
-
-        @DisplayName("commentId = null로 들어오는 comment 좋아요 취소")
-        @Test
-        public void unlike() {
-            Exception exception = assertThrows(Exception.class, () -> commentService.unlikeComment(commentId));
-            assertEquals(IllegalArgumentException.class, exception.getCause().getClass());
-            assertEquals("The given id must not be null!", exception.getCause().getMessage());
-        }
-    }
-
-    @DisplayName("대댓글 조회하기")
-    @Test
-    void nestedComment_read() {
-        CommentReqDto commentReqDto = new CommentReqDto("댓글");
-        Post post = postRepository.findById(postId).get();
-        CommentDto comment = commentService.createComment(postId, commentReqDto);
-        commentId = post.getComments().get(0).getId();
-        assertNotNull(comment);
-
-        CommentReqDto commentReqDto2 = new CommentReqDto("대댓글");
-        commentService.createNestedComment(commentId, commentReqDto2);
-
-        CommentReqDto commentReqDto3 = new CommentReqDto("대댓글2");
-        commentService.createNestedComment(commentId, commentReqDto3);
-
-        final Comment baseComment = commentRepository.findById(commentId).get();
-
-        assertThat(baseComment.getBaseComment()).isNull(); // 최상위 댓글
-        assertThat(baseComment.getContent()).isEqualTo("댓글");
-        assertThat(baseComment.getNestedComments().size()).isEqualTo(2);
-        assertThat(baseComment.getNestedComments()).extracting("content").containsExactly("대댓글", "대댓글2");
-    }
-
-    @DisplayName("존재하지 않는 대댓글 조회 시도")
-    @Test
-    void is_not_nestedComment() {
-        CommentReqDto commentReqDto = new CommentReqDto("댓글");
-        Post post = postRepository.findById(postId).get();
-        CommentDto commentDto = commentService.createComment(postId, commentReqDto);
-        assertNotNull(commentDto);
-
-        final Comment comment = post.getComments().get(0);
-
-        assertThat(comment.getBaseComment()).isNull(); // 최상위 댓글
-        assertThat(comment.getContent()).isEqualTo("댓글");
-        assertThat(comment.getNestedComments().size()).isEqualTo(0);
     }
 }

--- a/src/test/java/our/yurivongella/instagramclone/service/CommentServiceTest.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/CommentServiceTest.java
@@ -280,7 +280,11 @@ class CommentServiceTest extends TestBase {
             commentService.createNestedComment(commentDto.getId(), new CommentReqDto("대댓글2"));
 
             // then
+            CommentResDto nestedComments = commentService.findNestedComments(commentDto.getId(), null);
             Comment baseComment = commentRepository.findById(commentDto.getId()).get();
+
+            assertThat(nestedComments.getHasNext()).isFalse();
+            assertThat(nestedComments.getComments()).isNotEmpty();
 
             assertThat(baseComment.getBaseComment()).isNull(); // 최상위 댓글
             assertThat(baseComment.getContent()).isEqualTo("test comment");
@@ -296,9 +300,13 @@ class CommentServiceTest extends TestBase {
             CommentDto commentDto = commentService.createComment(postId, new CommentReqDto("test comment"));
 
             // when
+            CommentResDto nestedComments = commentService.findNestedComments(commentDto.getId(), null);
             Comment baseComment = commentRepository.findById(commentDto.getId()).get();
 
             // then
+            assertThat(nestedComments.getHasNext()).isFalse();
+            assertThat(nestedComments.getComments()).isEmpty();
+
             assertThat(baseComment.getBaseComment()).isNull(); // 최상위 댓글
             assertThat(baseComment.getContent()).isEqualTo("test comment");
             assertThat(baseComment.getNestedComments().size()).isEqualTo(0);

--- a/src/test/java/our/yurivongella/instagramclone/service/TestBase.java
+++ b/src/test/java/our/yurivongella/instagramclone/service/TestBase.java
@@ -18,10 +18,10 @@ import java.util.Collections;
 @SpringBootTest
 public abstract class TestBase {
     @MockBean
-    private S3Service s3Service;
+    protected S3Service s3Service;
 
     @Autowired
-    private MemberRepository memberRepository;
+    protected MemberRepository memberRepository;
 
     @Autowired
     private PasswordEncoder passwordEncoder;


### PR DESCRIPTION
## Description

#116 작업의 일환입니다.

CommentDto 에서 사용하는 `MemberDto` 타입을 `MemberResDto` 로 변경합니다.

그리고 댓글 조회 시 팔로우 여부, 좋아요 여부를 프록시로 조회하면 성능 이슈가 있기 때문에 repository 로 직접 호출해서 세팅해주도록 코드를 변경했습니다.

`SliceHelper` 로직을 이전에 DTO 안에 넣어달라구 리뷰 했는데 결국 다시 밖으로 뺐네요..

## Changes

- MemberDto -> MemberResDto 로 변경하구 이에 맞게 코드 수정
- Controller 응답 타입 명시
- CommentServiceTest 코드 리팩토링
